### PR TITLE
Handle DWM restart

### DIFF
--- a/Cairo Desktop/Cairo Desktop/SupportingClasses/AppBarWindow.cs
+++ b/Cairo Desktop/Cairo Desktop/SupportingClasses/AppBarWindow.cs
@@ -19,7 +19,8 @@ namespace CairoDesktop.SupportingClasses
         {
             DeviceChange,
             DisplayChange,
-            DpiChange
+            DpiChange,
+            DwmChange
         }
 
         // Window properties
@@ -225,6 +226,11 @@ namespace CairoDesktop.SupportingClasses
                 SetScreenProperties(ScreenSetupReason.DeviceChange);
                 handled = true;
             }
+            else if (msg == (int)NativeMethods.WM.DWMCOMPOSITIONCHANGED)
+            {
+                SetScreenProperties(ScreenSetupReason.DwmChange);
+                handled = true;
+            }
 
             // call custom implementations' window procedure
             return CustomWndProc(hwnd, msg, wParam, lParam, ref handled);
@@ -273,7 +279,16 @@ namespace CairoDesktop.SupportingClasses
             if ((Screen.Primary || reason == ScreenSetupReason.DpiChange) && processScreenChanges && !Startup.IsShuttingDown)
             {
                 CairoLogger.Instance.Debug("AppBarWindow: Calling screen setup due to " + reason);
-                WindowManager.Instance.NotifyDisplayChange(); // update Cairo window list based on new screen setup
+
+                switch (reason)
+                {
+                    case ScreenSetupReason.DwmChange:
+                        WindowManager.Instance.NotifyDwmChange();
+                        break;
+                    default:
+                        WindowManager.Instance.NotifyDisplayChange(); // update Cairo window list based on new screen setup
+                        break;
+                }
             }
         }
 

--- a/Cairo Desktop/Cairo Desktop/SupportingClasses/DesktopManager.cs
+++ b/Cairo Desktop/Cairo Desktop/SupportingClasses/DesktopManager.cs
@@ -2,9 +2,7 @@
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Windows.Controls;
-using System.Windows.Forms;
 using System.Windows.Media;
-using System.Windows.Threading;
 using CairoDesktop.Common;
 using CairoDesktop.Common.DesignPatterns;
 using CairoDesktop.Common.Helpers;
@@ -288,6 +286,7 @@ namespace CairoDesktop.SupportingClasses
         public void SetWindowManager(WindowManager manager)
         {
             windowManager = manager;
+            windowManager.DwmChanged += DwmChanged;
             windowManager.ScreensChanged += ScreensChanged;
         }
 
@@ -529,6 +528,16 @@ namespace CairoDesktop.SupportingClasses
             ResetPosition(e.DisplaysChanged);
         }
 
+        private void DwmChanged(object sender, WindowManagerEventArgs e)
+        {
+            if (DesktopWindow != null && AllowProgmanChild)
+            {
+                // When we are a child of progman, we need to handle redrawing when DWM restarts
+                DestroyDesktopWindow();
+                CreateDesktopWindow();
+            }
+        }
+
         private void OnShowDesktop(HotKey hotKey)
         {
             ToggleOverlay();
@@ -545,6 +554,12 @@ namespace CairoDesktop.SupportingClasses
 
         public void Dispose()
         {
+            if (windowManager != null)
+            {
+                windowManager.DwmChanged -= DwmChanged;
+                windowManager.ScreensChanged -= ScreensChanged;
+            }
+
             TeardownDesktop();
         }
     }

--- a/Cairo Desktop/Cairo Desktop/SupportingClasses/WindowManager.cs
+++ b/Cairo Desktop/Cairo Desktop/SupportingClasses/WindowManager.cs
@@ -22,6 +22,7 @@ namespace CairoDesktop.SupportingClasses
         public List<MenuBar> MenuBarWindows = new List<MenuBar>();
         public List<Taskbar> TaskbarWindows = new List<Taskbar>();
 
+        public EventHandler<WindowManagerEventArgs> DwmChanged;
         public EventHandler<WindowManagerEventArgs> ScreensChanged;
 
         public static System.Drawing.Size PrimaryMonitorSize
@@ -93,6 +94,14 @@ namespace CairoDesktop.SupportingClasses
             if (!IsSettingDisplays)
             {
                 ProcessDisplayChanges();
+            }
+        }
+
+        public void NotifyDwmChange()
+        {
+            lock (displaySetupLock)
+            {
+                DwmChanged?.Invoke(this, new WindowManagerEventArgs());
             }
         }
 

--- a/Cairo Desktop/Cairo Desktop/SupportingClasses/WindowManager.cs
+++ b/Cairo Desktop/Cairo Desktop/SupportingClasses/WindowManager.cs
@@ -12,8 +12,8 @@ namespace CairoDesktop.SupportingClasses
 {
     public sealed class WindowManager : SingletonObject<WindowManager>, IDisposable
     {
-        private bool hasCompletedInitialDisplaySetup = false;
-        private int pendingDisplayEvents = 0;
+        private bool hasCompletedInitialDisplaySetup;
+        private int pendingDisplayEvents;
         private readonly static object displaySetupLock = new object();
         private readonly DesktopManager desktopManager;
 

--- a/Cairo Desktop/Cairo Desktop/Taskbar.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/Taskbar.xaml.cs
@@ -51,6 +51,11 @@ namespace CairoDesktop
 
             Screen = screen;
 
+            if (!Screen.Primary && !Settings.Instance.EnableMenuBarMultiMon)
+            {
+                processScreenChanges = true;
+            }
+
             setupTaskbar();
             setupTaskbarAppearance();
         }


### PR DESCRIPTION
Added notification to WindowManager for DWM restarts. Screen event windows trigger the notification. DesktopManager listens for the notification to redraw the desktop in the case where we are a child of Program Manager, when the Desktop window doesn't receive the window message.

Also fixed a hole in the per-monitor DPI change handling logic when only the taskbar and not menu bar is configured to appear on multiple monitors. Now the taskbars can be screen event windows in this case so that per-monitor DPI change messages are received.