### PR TITLE
Fix crash when recreating desktop window while overlay is open

### DIFF
--- a/Cairo Desktop/Cairo Desktop/SupportingClasses/DesktopManager.cs
+++ b/Cairo Desktop/Cairo Desktop/SupportingClasses/DesktopManager.cs
@@ -250,7 +250,7 @@ namespace CairoDesktop.SupportingClasses
         {
             if (DesktopWindow != null)
             {
-                if (DesktopIconsControl != null)
+                if (DesktopIconsControl != null && DesktopOverlayWindow == null)
                 {
                     DesktopWindow.grid.Children.Add(DesktopIconsControl);
                 }


### PR DESCRIPTION
Without this fix, we attempt to add the desktop icons control to the new desktop window, even though it is already part of the overlay window, causing an error.