### PR TITLE
Refactor exit logic to occur in all graceful exit scenarios

### DIFF
--- a/Cairo Desktop/Cairo Desktop/CairoSettingsWindow.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/CairoSettingsWindow.xaml.cs
@@ -510,7 +510,7 @@ namespace CairoDesktop
         {
             saveChanges();
 
-            Startup.Restart();
+            Startup.RestartCairo();
         }
 
         /// <summary>

--- a/Cairo Desktop/Cairo Desktop/MenuBar.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/MenuBar.xaml.cs
@@ -502,7 +502,7 @@ namespace CairoDesktop
             bool? CloseCairoChoice = CairoMessage.ShowOkCancel(Localization.DisplayString.sExitCairo_Info, Localization.DisplayString.sExitCairo_Title, "Resources/exitIcon.png", Localization.DisplayString.sExitCairo_ExitCairo, Localization.DisplayString.sInterface_Cancel);
             if (CloseCairoChoice.HasValue && CloseCairoChoice.Value)
             {
-                Startup.Shutdown();
+                Startup.ExitCairo();
             }
         }
 

--- a/Cairo Desktop/Cairo Desktop/Startup.InitializationRoutines.cs
+++ b/Cairo Desktop/Cairo Desktop/Startup.InitializationRoutines.cs
@@ -33,7 +33,7 @@ namespace CairoDesktop
 
         private static void SetupUpdateManager()
         {
-            UpdateManager.Instance.Initialize();
+            UpdateManager.Instance.Initialize(ExitCairo);
         }
 
         private static bool SingleInstanceCheck()

--- a/Cairo Desktop/Cairo Desktop/Startup.cs
+++ b/Cairo Desktop/Cairo Desktop/Startup.cs
@@ -58,14 +58,6 @@ namespace CairoDesktop
 
             setTheme(app);
 
-
-            // Future: This should be moved to whatever plugin is responsible for Taskbar stuff
-            if (Settings.Instance.EnableTaskbar)
-            {
-                AppBarHelper.SetWinTaskbarState(AppBarHelper.WinTaskbarState.AutoHide);
-                AppBarHelper.SetWinTaskbarVisibility((int)NativeMethods.SetWindowPosFlags.SWP_HIDEWINDOW);
-            }
-
             // Future: This should be moved to whatever plugin is responsible for MenuBar stuff
             MenuBar initialMenuBar = new MenuBar(System.Windows.Forms.Screen.PrimaryScreen);
             app.MainWindow = initialMenuBar;
@@ -75,6 +67,7 @@ namespace CairoDesktop
             // Future: This should be moved to whatever plugin is responsible for Taskbar stuff
             if (Settings.Instance.EnableTaskbar)
             {
+                AppBarHelper.HideWindowsTaskbar();
                 Taskbar initialTaskbar = new Taskbar(System.Windows.Forms.Screen.PrimaryScreen);
                 WindowManager.Instance.TaskbarWindows.Add(initialTaskbar);
                 initialTaskbar.Show();
@@ -127,7 +120,7 @@ namespace CairoDesktop
             }
         }
 
-        public static void Restart()
+        public static void RestartCairo()
         {
             try
             {
@@ -138,27 +131,20 @@ namespace CairoDesktop
                 current.Start();
 
                 // close this instance
-                Shutdown();
+                ExitCairo();
             }
             catch
             { }
         }
 
-        public static void Shutdown()
+        public static void ExitCairo()
         {
             IsShuttingDown = true;
 
-            NotificationArea.Instance.Dispose();
-
             if (Shell.IsCairoRunningAsShell)
             {
-                WindowManager.ResetWorkArea();
                 indicateGracefulShutdown();
             }
-
-            Shell.DisposeIml();
-            WindowManager.Instance.Dispose();
-            UpdateManager.Instance.Dispose();
 
             Application.Current?.Dispatcher.Invoke(() => Application.Current?.Shutdown(), DispatcherPriority.Normal);
         }

--- a/Cairo Desktop/Cairo Desktop/SupportingClasses/AppBarWindow.cs
+++ b/Cairo Desktop/Cairo Desktop/SupportingClasses/AppBarWindow.cs
@@ -91,21 +91,7 @@ namespace CairoDesktop.SupportingClasses
 
             CustomClosing();
 
-            if (Startup.IsShuttingDown && Screen.Primary)
-            {
-                // unregister AppBar
-                if (AppBarHelper.appBars.Contains(Handle))
-                {
-                    AppBarHelper.RegisterBar(this, ActualWidth * dpiScale, desiredHeight * dpiScale);
-                }
-
-                // unregister full-screen notifications
-                FullScreenHelper.Instance.FullScreenApps.CollectionChanged -= FullScreenApps_CollectionChanged;
-
-                // dispose the full screen helper since we are the primary instance
-                FullScreenHelper.Instance.Dispose();
-            }
-            else if (WindowManager.Instance.IsSettingDisplays || Startup.IsShuttingDown)
+            if (WindowManager.Instance.IsSettingDisplays || Startup.IsShuttingDown)
             {
                 // unregister AppBar
                 if (AppBarHelper.appBars.Contains(Handle))
@@ -311,8 +297,7 @@ namespace CairoDesktop.SupportingClasses
             // apparently the TaskBars like to pop up when AppBars change
             if (Settings.Instance.EnableTaskbar && !Startup.IsShuttingDown)
             {
-                AppBarHelper.SetWinTaskbarState(AppBarHelper.WinTaskbarState.AutoHide);
-                AppBarHelper.SetWinTaskbarVisibility((int)NativeMethods.SetWindowPosFlags.SWP_HIDEWINDOW);
+                AppBarHelper.HideWindowsTaskbar();
             }
 
             if (!isSameCoords)

--- a/Cairo Desktop/Cairo Desktop/SupportingClasses/UpdateManager.cs
+++ b/Cairo Desktop/Cairo Desktop/SupportingClasses/UpdateManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using CairoDesktop.Common.DesignPatterns;
+using CairoDesktop.Common.Logging;
 using CairoDesktop.Interop;
 
 namespace CairoDesktop.SupportingClasses
@@ -15,20 +16,26 @@ namespace CairoDesktop.SupportingClasses
         }
 
         private bool isInitialized;
-        private WinSparkle.win_sparkle_can_shutdown_callback_t canShutdownDelegate;
-        private WinSparkle.win_sparkle_shutdown_request_callback_t shutdownDelegate;
+        private WinSparkle.win_sparkle_can_shutdown_callback_t CanShutdownDelegate;
+        private WinSparkle.win_sparkle_shutdown_request_callback_t ShutdownDelegate;
 
         private UpdateManager() { }
 
-        public void Initialize()
+        public void Initialize(WinSparkle.win_sparkle_shutdown_request_callback_t shutdownDelegate)
         {
             if (!isInitialized)
             {
+                if (shutdownDelegate == null)
+                {
+                    CairoLogger.Instance.Error("UpdateManager: Unable to initialize; shutdownDelegate is null");
+                    return;
+                }
+
                 WinSparkle.win_sparkle_set_appcast_url(UpdateUrl);
-                canShutdownDelegate = canShutdown;
-                shutdownDelegate = Startup.Shutdown;
-                WinSparkle.win_sparkle_set_can_shutdown_callback(canShutdownDelegate);
-                WinSparkle.win_sparkle_set_shutdown_request_callback(shutdownDelegate);
+                CanShutdownDelegate = canShutdown;
+                ShutdownDelegate = shutdownDelegate;
+                WinSparkle.win_sparkle_set_can_shutdown_callback(CanShutdownDelegate);
+                WinSparkle.win_sparkle_set_shutdown_request_callback(ShutdownDelegate);
                 WinSparkle.win_sparkle_init();
                 isInitialized = true;
             }

--- a/Cairo Desktop/Cairo Desktop/SupportingClasses/WindowManager.cs
+++ b/Cairo Desktop/Cairo Desktop/SupportingClasses/WindowManager.cs
@@ -497,15 +497,19 @@ namespace CairoDesktop.SupportingClasses
 
         public static void ResetWorkArea()
         {
-            // TODO this is wrong for multi-display
-            // set work area back to full screen size. we can't assume what pieces of the old work area may or may not be still used
-            NativeMethods.Rect oldWorkArea;
-            oldWorkArea.Left = SystemInformation.VirtualScreen.Left;
-            oldWorkArea.Top = SystemInformation.VirtualScreen.Top;
-            oldWorkArea.Right = SystemInformation.VirtualScreen.Right;
-            oldWorkArea.Bottom = SystemInformation.VirtualScreen.Bottom;
+            if (Shell.IsCairoRunningAsShell)
+            {
+                // TODO this is wrong for multi-display
+                // set work area back to full screen size. we can't assume what pieces of the old work area may or may not be still used
+                NativeMethods.Rect oldWorkArea;
+                oldWorkArea.Left = SystemInformation.VirtualScreen.Left;
+                oldWorkArea.Top = SystemInformation.VirtualScreen.Top;
+                oldWorkArea.Right = SystemInformation.VirtualScreen.Right;
+                oldWorkArea.Bottom = SystemInformation.VirtualScreen.Bottom;
 
-            NativeMethods.SystemParametersInfo((int)NativeMethods.SPI.SETWORKAREA, 1, ref oldWorkArea, (uint)(NativeMethods.SPIF.UPDATEINIFILE | NativeMethods.SPIF.SENDWININICHANGE));
+                NativeMethods.SystemParametersInfo((int) NativeMethods.SPI.SETWORKAREA, 1, ref oldWorkArea,
+                    (uint) (NativeMethods.SPIF.UPDATEINIFILE | NativeMethods.SPIF.SENDWININICHANGE));
+            }
         }
         #endregion
 

--- a/Cairo Desktop/Cairo Desktop/Taskbar.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/Taskbar.xaml.cs
@@ -71,6 +71,7 @@ namespace CairoDesktop
             CanAutoHide = true;
 
             // setup taskbar item source
+            WindowsTasks.WindowsTasksService.Instance.Initialize();
             TasksList.ItemsSource = WindowsTasks.WindowsTasksService.Instance.GroupedWindows;
             TasksList2.ItemsSource = WindowsTasks.WindowsTasksService.Instance.GroupedWindows;
             if (WindowsTasks.WindowsTasksService.Instance.GroupedWindows != null) WindowsTasks.WindowsTasksService.Instance.GroupedWindows.CollectionChanged += GroupedWindows_Changed;
@@ -206,17 +207,7 @@ namespace CairoDesktop
 
         protected override void CustomClosing()
         {
-            if (Startup.IsShuttingDown && Screen.Primary)
-            {
-                // Manually call dispose on window close...
-                WindowsTasks.WindowsTasksService.Instance.GroupedWindows.CollectionChanged -= GroupedWindows_Changed;
-                WindowsTasks.WindowsTasksService.Instance.Dispose();
-
-                // show the windows taskbar again
-                AppBarHelper.SetWinTaskbarState(AppBarHelper.WinTaskbarState.OnTop);
-                AppBarHelper.SetWinTaskbarVisibility((int)NativeMethods.SetWindowPosFlags.SWP_SHOWWINDOW);
-            }
-            else if (WindowManager.Instance.IsSettingDisplays || Startup.IsShuttingDown)
+            if (WindowManager.Instance.IsSettingDisplays || Startup.IsShuttingDown)
             {
                 WindowsTasks.WindowsTasksService.Instance.GroupedWindows.CollectionChanged -= GroupedWindows_Changed;
             }

--- a/Cairo Desktop/Cairo Desktop/Welcome.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/Welcome.xaml.cs
@@ -99,7 +99,7 @@ namespace CairoDesktop
             if (Settings.Instance.Language != _language)
             {
                 CairoMessage.Show(DisplayString.sWelcome_ChangingLanguageText, DisplayString.sWelcome_ChangingLanguage, MessageBoxButton.OK, MessageBoxImage.Information);
-                Startup.Restart();
+                Startup.RestartCairo();
             }
         }
     }


### PR DESCRIPTION
Allows us to keep track of Explorer taskbar state and restore it on exit (#320)