### PR TITLE
Fix crash on Win-Shift-D

### DIFF
--- a/Cairo Desktop/Cairo Desktop/SupportingClasses/DesktopManager.cs
+++ b/Cairo Desktop/Cairo Desktop/SupportingClasses/DesktopManager.cs
@@ -31,6 +31,7 @@ namespace CairoDesktop.SupportingClasses
         }
 
         private bool isOverlayOpen;
+        private bool isOverlayClosing;
         private int renderOverlayFrames;
         private HotKey overlayHotKey;
         private WindowManager windowManager;
@@ -324,6 +325,11 @@ namespace CairoDesktop.SupportingClasses
         #region Overlay
         private void OpenOverlay()
         {
+            if (isOverlayClosing)
+            {
+                return;
+            }
+
             if (DesktopOverlayWindow == null && DesktopWindow != null && DesktopIconsControl != null)
             {
                 DesktopOverlayWindow = new DesktopOverlay(this);
@@ -365,8 +371,15 @@ namespace CairoDesktop.SupportingClasses
 
         private void CloseOverlay()
         {
+            if (isOverlayClosing)
+            {
+                return;
+            }
+
             if (DesktopOverlayWindow != null && DesktopWindow != null && DesktopIconsControl != null)
             {
+                isOverlayClosing = true;
+
                 // create mask image to show while the icons control is rendered on the desktop window
                 Image maskImage = new Image();
                 maskImage.Source = DesktopIconsControl?.GenerateBitmap(DesktopOverlayWindow.grid);
@@ -424,6 +437,9 @@ namespace CairoDesktop.SupportingClasses
 
                 // we're done here, stop this callback from executing again
                 CompositionTarget.Rendering -= CloseOverlay_CompositionTarget_Rendering;
+
+                isOverlayClosing = false;
+                IsOverlayOpen = false;
             }
 
             renderOverlayFrames++;

--- a/Cairo Desktop/Cairo Desktop/SupportingClasses/DesktopManager.cs
+++ b/Cairo Desktop/Cairo Desktop/SupportingClasses/DesktopManager.cs
@@ -48,7 +48,7 @@ namespace CairoDesktop.SupportingClasses
             }
             set
             {
-                if (isOverlayOpen != value)
+                if (isOverlayOpen != value && !isOverlayClosing)
                 {
                     isOverlayOpen = value;
 
@@ -325,11 +325,6 @@ namespace CairoDesktop.SupportingClasses
         #region Overlay
         private void OpenOverlay()
         {
-            if (isOverlayClosing)
-            {
-                return;
-            }
-
             if (DesktopOverlayWindow == null && DesktopWindow != null && DesktopIconsControl != null)
             {
                 DesktopOverlayWindow = new DesktopOverlay(this);
@@ -371,11 +366,6 @@ namespace CairoDesktop.SupportingClasses
 
         private void CloseOverlay()
         {
-            if (isOverlayClosing)
-            {
-                return;
-            }
-
             if (DesktopOverlayWindow != null && DesktopWindow != null && DesktopIconsControl != null)
             {
                 isOverlayClosing = true;
@@ -439,7 +429,6 @@ namespace CairoDesktop.SupportingClasses
                 CompositionTarget.Rendering -= CloseOverlay_CompositionTarget_Rendering;
 
                 isOverlayClosing = false;
-                IsOverlayOpen = false;
             }
 
             renderOverlayFrames++;


### PR DESCRIPTION
The desktop overlay takes 2 frames to close while the icons control migrates, and holding the hotkey previously caused this to race with the overlay toggle. Now changing the overlay state while it is in the process of closing is basically a no-op.