### PR TITLE
Scrape Explorer tray for icons which don't respond to TaskbarCreated 

### DIFF
--- a/Cairo Desktop/CairoDesktop.Interop/NativeMethods.User32.cs
+++ b/Cairo Desktop/CairoDesktop.Interop/NativeMethods.User32.cs
@@ -1578,6 +1578,9 @@ namespace CairoDesktop.Interop
         [DllImport(User32_DllName, SetLastError = true)]
         public static extern IntPtr FindWindowEx(IntPtr parentHandle, IntPtr childAfter, string className, string windowTitle);
 
+        [DllImport(User32_DllName, SetLastError = true)]
+        public static extern IntPtr FindWindowEx(IntPtr parentHandle, IntPtr childAfter, string className, IntPtr windowTitle);
+
         [DllImport(User32_DllName, CharSet = CharSet.Auto)]
         public static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
 

--- a/Cairo Desktop/CairoDesktop.Interop/NativeMethods.cs
+++ b/Cairo Desktop/CairoDesktop.Interop/NativeMethods.cs
@@ -1395,5 +1395,96 @@ namespace CairoDesktop.Interop
 
         [DllImport("gdi32.dll")]
         public static extern IntPtr CreateSolidBrush(uint crColor);
+
+        [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
+        public static extern IntPtr VirtualAllocEx(IntPtr hProcess, IntPtr lpAddress,
+            uint dwSize, AllocationType flAllocationType, MemoryProtection flProtect);
+
+        [Flags]
+        public enum AllocationType
+        {
+            Commit = 0x1000,
+            Reserve = 0x2000,
+            Decommit = 0x4000,
+            Release = 0x8000,
+            Reset = 0x80000,
+            Physical = 0x400000,
+            TopDown = 0x100000,
+            WriteWatch = 0x200000,
+            LargePages = 0x20000000
+        }
+
+        [Flags]
+        public enum MemoryProtection
+        {
+            Execute = 0x10,
+            ExecuteRead = 0x20,
+            ExecuteReadWrite = 0x40,
+            ExecuteWriteCopy = 0x80,
+            NoAccess = 0x01,
+            ReadOnly = 0x02,
+            ReadWrite = 0x04,
+            WriteCopy = 0x08,
+            GuardModifierflag = 0x100,
+            NoCacheModifierflag = 0x200,
+            WriteCombineModifierflag = 0x400
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool ReadProcessMemory(
+            IntPtr hProcess,
+            IntPtr lpBaseAddress,
+            IntPtr lpBuffer,
+            Int32 nSize,
+            out IntPtr lpNumberOfBytesRead);
+
+        [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
+        public static extern bool VirtualFreeEx(IntPtr hProcess, IntPtr lpAddress,
+            int dwSize, AllocationType dwFreeType);
+
+        public enum TB : uint
+        {
+            GETBUTTON = WM.USER + 23,
+            BUTTONCOUNT = WM.USER + 24
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public struct TrayItem
+        {
+            public IntPtr hWnd;
+            public uint uID;
+            public uint uCallbackMessage;
+            public uint dwState;
+            public uint uVersion;
+            public IntPtr hIcon;
+            public ulong uIconDemoteTimerID;
+            public uint dwUserPref;
+            public uint dwLastSoundTime;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)]
+            public string szExeName;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)]
+            public string szIconText;
+            public uint uNumSeconds;
+            public Guid guidItem;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct TBBUTTON
+        {
+            public int iBitmap;
+            public int idCommand;
+            [StructLayout(LayoutKind.Explicit)]
+            private struct TBBUTTON_U
+            {
+                [FieldOffset(0)] public byte fsState;
+                [FieldOffset(1)] public byte fsStyle;
+                [FieldOffset(0)] private IntPtr bReserved;
+            }
+            private TBBUTTON_U union;
+            public byte fsState { get { return union.fsState; } set { union.fsState = value; } }
+            public byte fsStyle { get { return union.fsStyle; } set { union.fsStyle = value; } }
+            public IntPtr dwData;
+            public IntPtr iString;
+        }
     }
 }

--- a/Cairo Desktop/CairoDesktop.Interop/NativeMethods.cs
+++ b/Cairo Desktop/CairoDesktop.Interop/NativeMethods.cs
@@ -1438,6 +1438,14 @@ namespace CairoDesktop.Interop
             Int32 nSize,
             out IntPtr lpNumberOfBytesRead);
 
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool ReadProcessMemory(
+            IntPtr hProcess,
+            UIntPtr lpBaseAddress,
+            IntPtr lpBuffer,
+            Int32 nSize,
+            out IntPtr lpNumberOfBytesRead);
+
         [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true)]
         public static extern bool VirtualFreeEx(IntPtr hProcess, IntPtr lpAddress,
             int dwSize, AllocationType dwFreeType);
@@ -1457,7 +1465,7 @@ namespace CairoDesktop.Interop
             public uint dwState;
             public uint uVersion;
             public IntPtr hIcon;
-            public ulong uIconDemoteTimerID;
+            public IntPtr uIconDemoteTimerID;
             public uint dwUserPref;
             public uint dwLastSoundTime;
             [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)]
@@ -1483,7 +1491,7 @@ namespace CairoDesktop.Interop
             private TBBUTTON_U union;
             public byte fsState { get { return union.fsState; } set { union.fsState = value; } }
             public byte fsStyle { get { return union.fsStyle; } set { union.fsStyle = value; } }
-            public IntPtr dwData;
+            public UIntPtr dwData;
             public IntPtr iString;
         }
     }

--- a/Cairo Desktop/CairoDesktop.Interop/Shell.cs
+++ b/Cairo Desktop/CairoDesktop.Interop/Shell.cs
@@ -677,21 +677,25 @@ namespace CairoDesktop.Interop
 
         public static string GetPathForHandle(IntPtr hWnd)
         {
+            StringBuilder outFileName = new StringBuilder(1024);
+
             // get process id
             uint procId;
             GetWindowThreadProcessId(hWnd, out procId);
 
-            // open process
-            // QueryLimitedInformation flag allows us to access elevated applications as well
-            IntPtr hProc = OpenProcess(ProcessAccessFlags.QueryLimitedInformation, false, (int)procId);
+            if (procId != 0)
+            {
+                // open process
+                // QueryLimitedInformation flag allows us to access elevated applications as well
+                IntPtr hProc = OpenProcess(ProcessAccessFlags.QueryLimitedInformation, false, (int) procId);
 
-            // get filename
-            StringBuilder outFileName = new StringBuilder(1024);
-            int len = outFileName.Capacity;
-            QueryFullProcessImageName(hProc, 0, outFileName, ref len);
+                // get filename
+                int len = outFileName.Capacity;
+                QueryFullProcessImageName(hProc, 0, outFileName, ref len);
 
-            outFileName.Replace("Excluded,", "");
-            outFileName.Replace(",SFC protected", "");
+                outFileName.Replace("Excluded,", "");
+                outFileName.Replace(",SFC protected", "");
+            }
 
             return outFileName.ToString();
         }

--- a/Cairo Desktop/CairoDesktop.WindowsTray/CairoDesktop.WindowsTray.csproj
+++ b/Cairo Desktop/CairoDesktop.WindowsTray/CairoDesktop.WindowsTray.csproj
@@ -84,6 +84,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Delegates.cs" />
+    <Compile Include="ExplorerTrayService.cs" />
     <Compile Include="NotificationArea.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="NotifyIcon.cs" />

--- a/Cairo Desktop/CairoDesktop.WindowsTray/CairoDesktop.WindowsTray.csproj
+++ b/Cairo Desktop/CairoDesktop.WindowsTray/CairoDesktop.WindowsTray.csproj
@@ -90,6 +90,7 @@
     <Compile Include="NotifyIcon.cs" />
     <Compile Include="ShellServiceObject.cs" />
     <Compile Include="SysTrayObject.cs" />
+    <Compile Include="TrayNotify.cs" />
     <Compile Include="TrayService.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Cairo Desktop/CairoDesktop.WindowsTray/ExplorerTrayService.cs
+++ b/Cairo Desktop/CairoDesktop.WindowsTray/ExplorerTrayService.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using CairoDesktop.Common.DesignPatterns;
+using CairoDesktop.Common.Logging;
+using CairoDesktop.Interop;
+using static CairoDesktop.Interop.NativeMethods;
+
+namespace CairoDesktop.WindowsTray
+{
+    internal class ExplorerTrayService: SingletonObject<ExplorerTrayService>
+    {
+        private SystrayDelegate trayDelegate;
+        private IntPtr toolbarHwnd;
+
+        private ExplorerTrayService() { }
+
+        public void SetSystrayCallback(SystrayDelegate theDelegate)
+        {
+            trayDelegate = theDelegate;
+        }
+
+        public void Run()
+        {
+            if (!Shell.IsCairoRunningAsShell && trayDelegate != null)
+            {
+                toolbarHwnd = FindExplorerTrayToolbarHwnd();
+                GetTrayItems();
+            }
+        }
+
+        private IntPtr FindExplorerTrayToolbarHwnd()
+        {
+            IntPtr hwnd = FindWindow("Shell_TrayWnd", "");
+
+            if (hwnd != IntPtr.Zero)
+            {
+                hwnd = FindWindowEx(hwnd, IntPtr.Zero, "TrayNotifyWnd", "");
+
+                if (hwnd != IntPtr.Zero)
+                {
+                    hwnd = FindWindowEx(hwnd, IntPtr.Zero, "SysPager", "");
+
+                    if (hwnd != IntPtr.Zero)
+                    {
+                        hwnd = FindWindowEx(hwnd, IntPtr.Zero, "ToolbarWindow32", IntPtr.Zero);
+
+                        return hwnd;
+                    }
+                }
+            }
+
+            return IntPtr.Zero;
+        }
+
+        private int GetNumTrayIcons()
+        {
+            return (int)SendMessage(toolbarHwnd, (int)TB.BUTTONCOUNT, IntPtr.Zero, IntPtr.Zero);
+        }
+
+        private TrayItem GetTrayItem(int i, IntPtr hBuffer, IntPtr hProcess)
+        {
+            TBBUTTON tbButton = new TBBUTTON();
+            TrayItem trayItem = new TrayItem();
+            IntPtr hTBButton = Marshal.AllocHGlobal(Marshal.SizeOf(tbButton));
+            IntPtr hTrayItemBuffer = Marshal.AllocHGlobal(Marshal.SizeOf(trayItem));
+
+            IntPtr msgSuccess = SendMessage(toolbarHwnd, (int)TB.GETBUTTON, (IntPtr)i, hBuffer);
+            if (ReadProcessMemory(hProcess, hBuffer, hTBButton, Marshal.SizeOf(tbButton), out _))
+            {
+                tbButton = (TBBUTTON)Marshal.PtrToStructure(hTBButton, typeof(TBBUTTON));
+
+                if (ReadProcessMemory(hProcess, tbButton.dwData, hTrayItemBuffer, Marshal.SizeOf(trayItem), out _))
+                {
+                    trayItem = (TrayItem)Marshal.PtrToStructure(hTrayItemBuffer, typeof(TrayItem));
+
+                    CairoLogger.Instance.Debug(
+                        $"ExplorerTrayService: Got tray item: {trayItem.szIconText}");
+                }
+            }
+
+            return trayItem;
+        }
+
+        private void GetTrayItems()
+        {
+            int count = GetNumTrayIcons();
+
+            GetWindowThreadProcessId(toolbarHwnd, out var processId);
+            IntPtr hProcess = OpenProcess(ProcessAccessFlags.All, false, (int)processId);
+            IntPtr hBuffer = VirtualAllocEx(hProcess, IntPtr.Zero, (uint)Marshal.SizeOf(new TBBUTTON()), AllocationType.Commit,
+                MemoryProtection.ReadWrite);
+
+            for (int i = 0; i < count; i++)
+            {
+                NOTIFYICONDATA nid = GetTrayItemNID(GetTrayItem(i, hBuffer, hProcess));
+
+                if (trayDelegate != null)
+                {
+                    if (!trayDelegate((uint)NIM.NIM_ADD, nid))
+                    {
+                        CairoLogger.Instance.Debug("ExplorerTrayService: Ignored notify icon message");
+                    }
+                }
+            }
+
+            VirtualFreeEx(hProcess, hBuffer, 0, AllocationType.Release);
+
+            CloseHandle((int)hProcess);
+        }
+
+        private NOTIFYICONDATA GetTrayItemNID(TrayItem trayItem)
+        {
+            NOTIFYICONDATA nid = new NOTIFYICONDATA();
+
+            nid.hWnd = (uint)trayItem.hWnd;
+            nid.uID = trayItem.uID;
+            nid.uCallbackMessage = trayItem.uCallbackMessage;
+            nid.szTip = trayItem.szIconText;
+            nid.hIcon = (uint)trayItem.hIcon;
+            nid.uVersion = trayItem.uVersion;
+            nid.guidItem = trayItem.guidItem;
+            nid.dwState = 0;
+            nid.uFlags = NIF.GUID | NIF.ICON | NIF.MESSAGE | NIF.TIP;
+
+            return nid;
+        }
+    }
+}

--- a/Cairo Desktop/CairoDesktop.WindowsTray/ExplorerTrayService.cs
+++ b/Cairo Desktop/CairoDesktop.WindowsTray/ExplorerTrayService.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 using CairoDesktop.Common.DesignPatterns;
 using CairoDesktop.Common.Logging;
 using CairoDesktop.Interop;
+using Microsoft.Win32;
 using static CairoDesktop.Interop.NativeMethods;
 
 namespace CairoDesktop.WindowsTray
@@ -10,7 +11,6 @@ namespace CairoDesktop.WindowsTray
     internal class ExplorerTrayService: SingletonObject<ExplorerTrayService>
     {
         private SystrayDelegate trayDelegate;
-        private IntPtr toolbarHwnd;
 
         private ExplorerTrayService() { }
 
@@ -23,9 +23,60 @@ namespace CairoDesktop.WindowsTray
         {
             if (!Shell.IsCairoRunningAsShell && trayDelegate != null)
             {
-                toolbarHwnd = FindExplorerTrayToolbarHwnd();
+                bool autoTrayEnabled = GetAutoTrayEnabled();
+
+                if (autoTrayEnabled)
+                {
+                    // we can't get tray icons that are in the hidden area, so disable that temporarily if enabled
+                    SetAutoTrayEnabled(false);
+                }
+
                 GetTrayItems();
+
+                if (autoTrayEnabled)
+                {
+                    SetAutoTrayEnabled(true);
+                }
             }
+        }
+
+        private void GetTrayItems()
+        {
+            IntPtr toolbarHwnd = FindExplorerTrayToolbarHwnd();
+
+            if (toolbarHwnd == IntPtr.Zero)
+            {
+                return;
+            }
+
+            int count = GetNumTrayIcons(toolbarHwnd);
+
+            if (count < 1)
+            {
+                return;
+            }
+
+            GetWindowThreadProcessId(toolbarHwnd, out var processId);
+            IntPtr hProcess = OpenProcess(ProcessAccessFlags.All, false, (int)processId);
+            IntPtr hBuffer = VirtualAllocEx(hProcess, IntPtr.Zero, (uint)Marshal.SizeOf(new TBBUTTON()), AllocationType.Commit,
+                MemoryProtection.ReadWrite);
+
+            for (int i = 0; i < count; i++)
+            {
+                NOTIFYICONDATA nid = GetTrayItemNID(GetTrayItem(i, hBuffer, hProcess, toolbarHwnd));
+
+                if (trayDelegate != null)
+                {
+                    if (!trayDelegate((uint)NIM.NIM_ADD, nid))
+                    {
+                        CairoLogger.Instance.Debug("ExplorerTrayService: Ignored notify icon message");
+                    }
+                }
+            }
+
+            VirtualFreeEx(hProcess, hBuffer, 0, AllocationType.Release);
+
+            CloseHandle((int)hProcess);
         }
 
         private IntPtr FindExplorerTrayToolbarHwnd()
@@ -52,26 +103,26 @@ namespace CairoDesktop.WindowsTray
             return IntPtr.Zero;
         }
 
-        private int GetNumTrayIcons()
+        private int GetNumTrayIcons(IntPtr toolbarHwnd)
         {
             return (int)SendMessage(toolbarHwnd, (int)TB.BUTTONCOUNT, IntPtr.Zero, IntPtr.Zero);
         }
 
-        private TrayItem GetTrayItem(int i, IntPtr hBuffer, IntPtr hProcess)
+        private TrayItem GetTrayItem(int i, IntPtr hBuffer, IntPtr hProcess, IntPtr toolbarHwnd)
         {
             TBBUTTON tbButton = new TBBUTTON();
             TrayItem trayItem = new TrayItem();
             IntPtr hTBButton = Marshal.AllocHGlobal(Marshal.SizeOf(tbButton));
-            IntPtr hTrayItemBuffer = Marshal.AllocHGlobal(Marshal.SizeOf(trayItem));
+            IntPtr hTrayItem = Marshal.AllocHGlobal(Marshal.SizeOf(trayItem));
 
             IntPtr msgSuccess = SendMessage(toolbarHwnd, (int)TB.GETBUTTON, (IntPtr)i, hBuffer);
             if (ReadProcessMemory(hProcess, hBuffer, hTBButton, Marshal.SizeOf(tbButton), out _))
             {
                 tbButton = (TBBUTTON)Marshal.PtrToStructure(hTBButton, typeof(TBBUTTON));
 
-                if (ReadProcessMemory(hProcess, tbButton.dwData, hTrayItemBuffer, Marshal.SizeOf(trayItem), out _))
+                if (ReadProcessMemory(hProcess, tbButton.dwData, hTrayItem, Marshal.SizeOf(trayItem), out _))
                 {
-                    trayItem = (TrayItem)Marshal.PtrToStructure(hTrayItemBuffer, typeof(TrayItem));
+                    trayItem = (TrayItem)Marshal.PtrToStructure(hTrayItem, typeof(TrayItem));
 
                     CairoLogger.Instance.Debug(
                         $"ExplorerTrayService: Got tray item: {trayItem.szIconText}");
@@ -81,48 +132,89 @@ namespace CairoDesktop.WindowsTray
             return trayItem;
         }
 
-        private void GetTrayItems()
-        {
-            int count = GetNumTrayIcons();
-
-            GetWindowThreadProcessId(toolbarHwnd, out var processId);
-            IntPtr hProcess = OpenProcess(ProcessAccessFlags.All, false, (int)processId);
-            IntPtr hBuffer = VirtualAllocEx(hProcess, IntPtr.Zero, (uint)Marshal.SizeOf(new TBBUTTON()), AllocationType.Commit,
-                MemoryProtection.ReadWrite);
-
-            for (int i = 0; i < count; i++)
-            {
-                NOTIFYICONDATA nid = GetTrayItemNID(GetTrayItem(i, hBuffer, hProcess));
-
-                if (trayDelegate != null)
-                {
-                    if (!trayDelegate((uint)NIM.NIM_ADD, nid))
-                    {
-                        CairoLogger.Instance.Debug("ExplorerTrayService: Ignored notify icon message");
-                    }
-                }
-            }
-
-            VirtualFreeEx(hProcess, hBuffer, 0, AllocationType.Release);
-
-            CloseHandle((int)hProcess);
-        }
-
         private NOTIFYICONDATA GetTrayItemNID(TrayItem trayItem)
         {
             NOTIFYICONDATA nid = new NOTIFYICONDATA();
+            bool iconSuccess = false;
 
             nid.hWnd = (uint)trayItem.hWnd;
             nid.uID = trayItem.uID;
             nid.uCallbackMessage = trayItem.uCallbackMessage;
             nid.szTip = trayItem.szIconText;
-            nid.hIcon = (uint)trayItem.hIcon;
+            try
+            {
+                nid.hIcon = (uint) trayItem.hIcon;
+
+                if (nid.hIcon != 0u)
+                {
+                    iconSuccess = true;
+                }
+            }
+            catch { }
             nid.uVersion = trayItem.uVersion;
             nid.guidItem = trayItem.guidItem;
             nid.dwState = 0;
-            nid.uFlags = NIF.GUID | NIF.ICON | NIF.MESSAGE | NIF.TIP;
+            nid.uFlags = NIF.GUID | NIF.MESSAGE | NIF.TIP;
+
+            if (iconSuccess)
+            {
+                nid.uFlags |= NIF.ICON;
+            }
+            else
+            {
+                CairoLogger.Instance.Warning($"ExplorerTrayService: Unable to use {trayItem.szIconText} icon handle for NOTIFYICONDATA struct");
+            }
 
             return nid;
+        }
+
+        private bool GetAutoTrayEnabled()
+        {
+            int enableAutoTray = 1;
+
+            try
+            {
+                RegistryKey explorerKey = Registry.CurrentUser.OpenSubKey("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer", false);
+
+                if (explorerKey != null)
+                {
+                    var enableAutoTrayValue = explorerKey.GetValue("EnableAutoTray");
+
+                    if (enableAutoTrayValue != null)
+                    {
+                        enableAutoTray = Convert.ToInt32(enableAutoTrayValue);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                CairoLogger.Instance.Debug($"ExplorerTrayService: Unable to get EnableAutoTray setting: {e.Message}");
+            }
+
+            return enableAutoTray == 1;
+        }
+
+        private void SetAutoTrayEnabled(bool enabled)
+        {
+            TrayNotify trayNotify = new TrayNotify();
+
+            try
+            {
+                if (Shell.IsWindows8OrBetter)
+                {
+                    var trayNotifyInstance = (ITrayNotify) trayNotify;
+                    trayNotifyInstance.EnableAutoTray(enabled);
+                }
+                else
+                {
+                    var trayNotifyInstance = (ITrayNotifyLegacy) trayNotify;
+                    trayNotifyInstance.EnableAutoTray(enabled);
+                }
+            }
+            finally
+            {
+                Marshal.ReleaseComObject(trayNotify);
+            }
         }
     }
 }

--- a/Cairo Desktop/CairoDesktop.WindowsTray/NotificationArea.cs
+++ b/Cairo Desktop/CairoDesktop.WindowsTray/NotificationArea.cs
@@ -82,6 +82,10 @@ namespace CairoDesktop.WindowsTray
                 trayDelegate = SysTrayCallback;
                 iconDataDelegate = IconDataCallback;
                 trayHostSizeDelegate = TrayHostSizeCallback;
+
+                ExplorerTrayService.Instance.SetSystrayCallback(trayDelegate);
+                ExplorerTrayService.Instance.Run();
+
                 TrayService.Instance.SetSystrayCallback(trayDelegate);
                 TrayService.Instance.SetIconDataCallback(iconDataDelegate);
                 TrayService.Instance.SetTrayHostSizeCallback(trayHostSizeDelegate);

--- a/Cairo Desktop/CairoDesktop.WindowsTray/SysTrayObject.cs
+++ b/Cairo Desktop/CairoDesktop.WindowsTray/SysTrayObject.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
 namespace CairoDesktop.WindowsTray
 {

--- a/Cairo Desktop/CairoDesktop.WindowsTray/TrayNotify.cs
+++ b/Cairo Desktop/CairoDesktop.WindowsTray/TrayNotify.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace CairoDesktop.WindowsTray
+{
+    [ComImport]
+    [Guid("25DEAD04-1EAC-4911-9E3A-AD0A4AB560FD")]
+    class TrayNotify
+    {
+    }
+
+    enum NOTIFYITEM_PREFERENCE
+    {
+        PREFERENCE_SHOW_WHEN_ACTIVE = 0,
+        PREFERENCE_SHOW_NEVER = 1,
+        PREFERENCE_SHOW_ALWAYS = 2
+    };
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    struct NOTIFYITEM
+    {
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string pszExeName;
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string pszIconText;
+        public IntPtr hIcon;
+        public IntPtr hWnd;
+        public NOTIFYITEM_PREFERENCE dwUserPref;
+        public uint uID;
+        public Guid guidItem;
+    };
+
+    [ComImport]
+    [Guid("D782CCBA-AFB0-43F1-94DB-FDA3779EACCB")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    interface INotificationCB
+    {
+        void Notify([In] uint nEvent, [In] ref NOTIFYITEM notifyItem);
+    }
+
+    [ComImport]
+    [Guid("FB852B2C-6BAD-4605-9551-F15F87830935")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    interface ITrayNotifyLegacy
+    {
+        void RegisterCallback([MarshalAs(UnmanagedType.Interface)] INotificationCB callback);
+        void SetPreference([In] ref NOTIFYITEM notifyItem);
+        void EnableAutoTray([In] bool enabled);
+    }
+
+    [ComImport]
+    [Guid("D133CE13-3537-48BA-93A7-AFCD5D2053B4")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    interface ITrayNotify
+    {
+        void RegisterCallback([MarshalAs(UnmanagedType.Interface)] INotificationCB callback, [Out] out ulong handle);
+        void UnregisterCallback([In] ulong handle);
+        void SetPreference([In] ref NOTIFYITEM notifyItem);
+        void EnableAutoTray([In] bool enabled);
+        void DoAction([In] bool enabled);
+    }
+}


### PR DESCRIPTION
This PR will get the icons that Explorer is currently displaying to seed our notification area. This is needed because some apps don't respond correctly to the TaskbarCreated message we emit upon creating our notification area, so we miss those icons. Some examples this fixes are the Bluetooth icon, Nvidia, and Wireguard.

When we are running as shell, this is not an issue, because we will run before these apps launch.