### PR TITLE
Improve NotifyIcon compatibility

### DIFF
--- a/Cairo Desktop/Cairo Desktop/CairoSettingsWindow.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/CairoSettingsWindow.xaml.cs
@@ -263,6 +263,11 @@ namespace CairoDesktop
             {
                 chkEnableMenuBarBlur.Visibility = Visibility.Collapsed;
                 chkEnableMenuExtraActionCenter.Visibility = Visibility.Collapsed;
+                chkEnableMenuExtraVolume.Visibility = Visibility.Collapsed;
+            }
+            else if (Shell.IsWindows10OrBetter && !Shell.IsCairoRunningAsShell)
+            {
+                chkEnableMenuExtraVolume.Visibility = Visibility.Collapsed;
             }
         }
 

--- a/Cairo Desktop/Cairo Desktop/MenuBar.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/MenuBar.xaml.cs
@@ -126,7 +126,7 @@ namespace CairoDesktop
                 MenuExtrasHost.Children.Add(systemTray);
             }
 
-            if (Settings.Instance.EnableMenuExtraVolume)
+            if (Settings.Instance.EnableMenuExtraVolume && Shell.IsWindows10OrBetter && Shell.IsCairoRunningAsShell)
             {
                 // add volume
                 menuExtraVolume = new MenuExtraVolume();

--- a/Cairo Desktop/CairoDesktop.Configuration/Properties/Settings.Designer.cs
+++ b/Cairo Desktop/CairoDesktop.Configuration/Properties/Settings.Designer.cs
@@ -494,7 +494,7 @@ namespace CairoDesktop.Configuration.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("7820ae76-23e3-4229-82c1-e41cb67d5b9c|7820ae75-23e3-4229-82c1-e41cb67d5b9c|7820ae7" +
-            "4-23e3-4229-82c1-e41cb67d5b9c")]
+            "4-23e3-4229-82c1-e41cb67d5b9c|7820ae73-23e3-4229-82c1-e41cb67d5b9c")]
         public string PinnedNotifyIcons {
             get {
                 return ((string)(this["PinnedNotifyIcons"]));

--- a/Cairo Desktop/CairoDesktop.Configuration/Properties/Settings.settings
+++ b/Cairo Desktop/CairoDesktop.Configuration/Properties/Settings.settings
@@ -120,7 +120,7 @@
       <Value Profile="(Default)">0,0</Value>
     </Setting>
     <Setting Name="PinnedNotifyIcons" Type="System.String" Scope="User">
-      <Value Profile="(Default)">7820ae76-23e3-4229-82c1-e41cb67d5b9c|7820ae75-23e3-4229-82c1-e41cb67d5b9c|7820ae74-23e3-4229-82c1-e41cb67d5b9c</Value>
+      <Value Profile="(Default)">7820ae76-23e3-4229-82c1-e41cb67d5b9c|7820ae75-23e3-4229-82c1-e41cb67d5b9c|7820ae74-23e3-4229-82c1-e41cb67d5b9c|7820ae73-23e3-4229-82c1-e41cb67d5b9c</Value>
     </Setting>
     <Setting Name="EnableTaskbarThumbnails" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>

--- a/Cairo Desktop/CairoDesktop.Configuration/app.config
+++ b/Cairo Desktop/CairoDesktop.Configuration/app.config
@@ -125,7 +125,7 @@
         <value>0,0</value>
       </setting>
       <setting name="PinnedNotifyIcons" serializeAs="String">
-        <value>7820ae76-23e3-4229-82c1-e41cb67d5b9c|7820ae75-23e3-4229-82c1-e41cb67d5b9c|7820ae74-23e3-4229-82c1-e41cb67d5b9c</value>
+        <value>7820ae76-23e3-4229-82c1-e41cb67d5b9c|7820ae75-23e3-4229-82c1-e41cb67d5b9c|7820ae74-23e3-4229-82c1-e41cb67d5b9c|7820ae73-23e3-4229-82c1-e41cb67d5b9c</value>
       </setting>
       <setting name="EnableTaskbarThumbnails" serializeAs="String">
         <value>True</value>

--- a/Cairo Desktop/CairoDesktop.Interop/NativeMethods.User32.cs
+++ b/Cairo Desktop/CairoDesktop.Interop/NativeMethods.User32.cs
@@ -1776,6 +1776,9 @@ namespace CairoDesktop.Interop
         [DllImport(User32_DllName, SetLastError = true, CharSet = CharSet.Auto)]
         public static extern bool SendNotifyMessage(IntPtr hWnd, uint Msg, UIntPtr wParam, IntPtr lParam);
 
+        [DllImport(User32_DllName, SetLastError = true, CharSet = CharSet.Auto)]
+        public static extern bool SendNotifyMessage(IntPtr hWnd, uint Msg, uint wParam, uint lParam);
+
         public static IntPtr HWND_BROADCAST = new IntPtr(0xffff);
         public static int WINEVENT_OUTOFCONTEXT = 0;
         public static int WINEVENT_SKIPOWNPROCESS = 2;

--- a/Cairo Desktop/CairoDesktop.WindowsTray/ExplorerTrayService.cs
+++ b/Cairo Desktop/CairoDesktop.WindowsTray/ExplorerTrayService.cs
@@ -120,12 +120,15 @@ namespace CairoDesktop.WindowsTray
             {
                 tbButton = (TBBUTTON)Marshal.PtrToStructure(hTBButton, typeof(TBBUTTON));
 
-                if (ReadProcessMemory(hProcess, tbButton.dwData, hTrayItem, Marshal.SizeOf(trayItem), out _))
+                if (tbButton.dwData != UIntPtr.Zero)
                 {
-                    trayItem = (TrayItem)Marshal.PtrToStructure(hTrayItem, typeof(TrayItem));
+                    if (ReadProcessMemory(hProcess, tbButton.dwData, hTrayItem, Marshal.SizeOf(trayItem), out _))
+                    {
+                        trayItem = (TrayItem) Marshal.PtrToStructure(hTrayItem, typeof(TrayItem));
 
-                    CairoLogger.Instance.Debug(
-                        $"ExplorerTrayService: Got tray item: {trayItem.szIconText}");
+                        CairoLogger.Instance.Debug(
+                            $"ExplorerTrayService: Got tray item: {trayItem.szIconText}");
+                    }
                 }
             }
 

--- a/Cairo Desktop/CairoDesktop.WindowsTray/NotificationArea.cs
+++ b/Cairo Desktop/CairoDesktop.WindowsTray/NotificationArea.cs
@@ -274,7 +274,7 @@ namespace CairoDesktop.WindowsTray
                                 trayIcon.Icon = Common.IconImageConverter.GetDefaultIcon();
 
                             TrayIcons.Add(trayIcon);
-                            CairoLogger.Instance.Debug($"NotificationArea: Added: {trayIcon.Title} Path: {trayIcon.Path} Hidden: {trayIcon.IsHidden} GUID: {trayIcon.GUID} UID: {trayIcon.UID}");
+                            CairoLogger.Instance.Debug($"NotificationArea: Added: {trayIcon.Title} Path: {trayIcon.Path} Hidden: {trayIcon.IsHidden} GUID: {trayIcon.GUID} UID: {trayIcon.UID} Version: {trayIcon.Version}");
 
                             if ((NIM)message == NIM.NIM_MODIFY)
                             {

--- a/Cairo Desktop/CairoDesktop.WindowsTray/NotificationArea.cs
+++ b/Cairo Desktop/CairoDesktop.WindowsTray/NotificationArea.cs
@@ -195,7 +195,8 @@ namespace CairoDesktop.WindowsTray
                     {
                         bool exists = false;
 
-                        if (nicData.guidItem == new Guid(VOLUME_GUID))
+                        // hide icons while we are shell which require UWP support & we have a separate implementation for
+                        if (nicData.guidItem == new Guid(VOLUME_GUID) && Shell.IsCairoRunningAsShell && Shell.IsWindows10OrBetter)
                             return false;
 
                         foreach (NotifyIcon ti in TrayIcons)

--- a/Cairo Desktop/CairoDesktop.WindowsTray/NotifyIcon.cs
+++ b/Cairo Desktop/CairoDesktop.WindowsTray/NotifyIcon.cs
@@ -322,6 +322,9 @@ namespace CairoDesktop.WindowsTray
         {
             CairoLogger.Instance.Debug(string.Format("{0} mouse button clicked icon: {1}", button.ToString(), Title));
 
+            // ensure our Shell_TrayWnd is topmost, which some icons require
+            TrayService.Instance.MakeTrayTopmost();
+
             uint wparam = UID;
 
             if (Version > 3)

--- a/Cairo Desktop/CairoDesktop.WindowsTray/NotifyIcon.cs
+++ b/Cairo Desktop/CairoDesktop.WindowsTray/NotifyIcon.cs
@@ -95,6 +95,24 @@ namespace CairoDesktop.WindowsTray
             }
         }
 
+        private bool _isHidden;
+
+        /// <summary>
+        /// Gets or sets whether or not the icon is hidden.
+        /// </summary>
+        public bool IsHidden
+        {
+            get
+            {
+                return _isHidden;
+            }
+            set
+            {
+                _isHidden = value;
+                OnPropertyChanged();
+            }
+        }
+
         private int _pinOrder;
 
         /// <summary>

--- a/Cairo Desktop/CairoDesktop.WindowsTray/NotifyIcon.cs
+++ b/Cairo Desktop/CairoDesktop.WindowsTray/NotifyIcon.cs
@@ -263,19 +263,22 @@ namespace CairoDesktop.WindowsTray
             if (!IsWindow(HWnd))
             {
                 NotificationArea.Instance.TrayIcons.Remove(this);
-                return;
             }
             else
             {
                 uint wparam = UID;
+                uint hiWord = 0;
 
                 if (Version > 3)
+                {
                     wparam = mouse;
+                    hiWord = UID;
+                }
 
-                PostMessage(HWnd, CallbackMessage, wparam, (uint)WM.MOUSEHOVER);
+                SendNotifyMessage(HWnd, CallbackMessage, wparam, (uint)WM.MOUSEHOVER | (hiWord << 16));
 
                 if (Version > 3)
-                    PostMessage(HWnd, CallbackMessage, wparam, NIN_POPUPOPEN);
+                    SendNotifyMessage(HWnd, CallbackMessage, wparam, NIN_POPUPOPEN | (hiWord << 16));
             }
         }
 
@@ -284,19 +287,22 @@ namespace CairoDesktop.WindowsTray
             if (!IsWindow(HWnd))
             {
                 NotificationArea.Instance.TrayIcons.Remove(this);
-                return;
             }
             else
             {
                 uint wparam = UID;
+                uint hiWord = 0;
 
                 if (Version > 3)
+                {
                     wparam = mouse;
+                    hiWord = UID;
+                }
 
-                PostMessage(HWnd, CallbackMessage, wparam, (uint)WM.MOUSELEAVE);
+                SendNotifyMessage(HWnd, CallbackMessage, wparam, (uint)WM.MOUSELEAVE | (hiWord << 16));
 
                 if (Version > 3)
-                    PostMessage(HWnd, CallbackMessage, wparam, NIN_POPUPCLOSE);
+                    SendNotifyMessage(HWnd, CallbackMessage, wparam, NIN_POPUPCLOSE | (hiWord << 16));
             }
         }
 
@@ -305,16 +311,19 @@ namespace CairoDesktop.WindowsTray
             if (!IsWindow(HWnd))
             {
                 NotificationArea.Instance.TrayIcons.Remove(this);
-                return;
             }
             else
             {
                 uint wparam = UID;
+                uint hiWord = 0;
 
                 if (Version > 3)
+                {
                     wparam = mouse;
+                    hiWord = UID;
+                }
 
-                PostMessage(HWnd, CallbackMessage, wparam, (uint)WM.MOUSEMOVE);
+                SendNotifyMessage(HWnd, CallbackMessage, wparam, (uint)WM.MOUSEMOVE | (hiWord << 16));
             }
         }
 
@@ -326,23 +335,27 @@ namespace CairoDesktop.WindowsTray
             TrayService.Instance.MakeTrayTopmost();
 
             uint wparam = UID;
+            uint hiWord = 0;
 
             if (Version > 3)
+            {
                 wparam = mouse;
+                hiWord = UID;
+            }
 
             if (button == MouseButton.Left)
             {
                 if (DateTime.Now.Subtract(_lastLClick).TotalMilliseconds <= doubleClickTime)
                 {
-                    PostMessage(HWnd, CallbackMessage, wparam, (uint)WM.LBUTTONDBLCLK);
+                    SendNotifyMessage(HWnd, CallbackMessage, wparam, (uint)WM.LBUTTONDBLCLK | (hiWord << 16));
                 }
                 else
                 {
-                    PostMessage(HWnd, CallbackMessage, wparam, (uint)WM.LBUTTONDOWN);
+                    SendNotifyMessage(HWnd, CallbackMessage, wparam, (uint)WM.LBUTTONDOWN | (hiWord << 16));
                 }
 
-                PostMessage(HWnd, CallbackMessage, wparam, (uint)WM.LBUTTONUP);
-                if (Version >= 4) PostMessage(HWnd, CallbackMessage, mouse, (NIN_SELECT | (UID << 16)));
+                SendNotifyMessage(HWnd, CallbackMessage, wparam, (uint)WM.LBUTTONUP | (hiWord << 16));
+                if (Version >= 4) SendNotifyMessage(HWnd, CallbackMessage, mouse, NIN_SELECT | (hiWord << 16));
 
                 _lastLClick = DateTime.Now;
             }
@@ -350,15 +363,15 @@ namespace CairoDesktop.WindowsTray
             {
                 if (DateTime.Now.Subtract(_lastRClick).TotalMilliseconds <= doubleClickTime)
                 {
-                    PostMessage(HWnd, CallbackMessage, wparam, (uint)WM.RBUTTONDBLCLK);
+                    SendNotifyMessage(HWnd, CallbackMessage, wparam, (uint)WM.RBUTTONDBLCLK | (hiWord << 16));
                 }
                 else
                 {
-                    PostMessage(HWnd, CallbackMessage, wparam, (uint)WM.RBUTTONDOWN);
+                    SendNotifyMessage(HWnd, CallbackMessage, wparam, (uint)WM.RBUTTONDOWN | (hiWord << 16));
                 }
 
-                PostMessage(HWnd, CallbackMessage, wparam, (uint)WM.RBUTTONUP);
-                if (Version >= 4) PostMessage(HWnd, CallbackMessage, mouse, ((uint)WM.CONTEXTMENU | (UID << 16)));
+                SendNotifyMessage(HWnd, CallbackMessage, wparam, (uint)WM.RBUTTONUP | (hiWord << 16));
+                if (Version >= 4) SendNotifyMessage(HWnd, CallbackMessage, mouse, (uint)WM.CONTEXTMENU | (hiWord << 16));
 
                 _lastRClick = DateTime.Now;
             }

--- a/Cairo Desktop/CairoDesktop.WindowsTray/TrayService.cs
+++ b/Cairo Desktop/CairoDesktop.WindowsTray/TrayService.cs
@@ -97,9 +97,7 @@ namespace CairoDesktop.WindowsTray
             // if we are above another tray, we will receive messages
             if (HwndTray != IntPtr.Zero)
             {
-                SetWindowPos(HwndTray, (IntPtr) WindowZOrder.HWND_TOPMOST, 0, 0, 0, 0,
-                    (int) SetWindowPosFlags.SWP_NOMOVE | (int) SetWindowPosFlags.SWP_NOACTIVATE |
-                    (int) SetWindowPosFlags.SWP_NOSIZE);
+                MakeTrayTopmost();
                 SetWindowsTrayBottommost();
             }
         }
@@ -355,6 +353,16 @@ namespace CairoDesktop.WindowsTray
                 SetWindowPos(taskbarHwnd, (IntPtr) WindowZOrder.HWND_BOTTOM, 0, 0, 0, 0,
                     (int) SetWindowPosFlags.SWP_NOMOVE | (int) SetWindowPosFlags.SWP_NOSIZE |
                     (int) SetWindowPosFlags.SWP_NOACTIVATE);
+            }
+        }
+
+        public void MakeTrayTopmost()
+        {
+            if (HwndTray != IntPtr.Zero)
+            {
+                SetWindowPos(HwndTray, (IntPtr)WindowZOrder.HWND_TOPMOST, 0, 0, 0, 0,
+                    (int)SetWindowPosFlags.SWP_NOMOVE | (int)SetWindowPosFlags.SWP_NOACTIVATE |
+                    (int)SetWindowPosFlags.SWP_NOSIZE);
             }
         }
         #endregion

--- a/Cairo Desktop/Extensions/CairoDesktop.Extensions.SystemMenuExtras/VolumeMenuExtra.cs
+++ b/Cairo Desktop/Extensions/CairoDesktop.Extensions.SystemMenuExtras/VolumeMenuExtra.cs
@@ -1,5 +1,6 @@
 ﻿using System.Windows.Controls;
 using CairoDesktop.Configuration;
+using CairoDesktop.Interop;
 using CairoDesktop.ObjectModel;
 
 namespace CairoDesktop.Extensions.SystemMenuExtras
@@ -12,7 +13,7 @@ namespace CairoDesktop.Extensions.SystemMenuExtras
 
         public override UserControl StartControl(MenuBar menuBar)
         {
-            if (Settings.Instance.EnableSysTray)
+            if (Settings.Instance.EnableSysTray && Shell.IsWindows10OrBetter && Shell.IsCairoRunningAsShell)
             {
                 _volume = new Volume();
                 return _volume;


### PR DESCRIPTION
- Improve handling of NotifyIcon hidden state
  - Only use the `dwState` value if `NIF_STATE` is specified. Also add hidden icons to our collection so that we have their existing properties in case they become visible.
  - This fixes Pantherbar (#265) and other apps that use the [Hardcodet.NotifyIcon.Wpf library](https://github.com/hardcodet/wpf-notifyicon).
- Fix system volume tray icon
  - This icon wasn't working previously because it requires `Shell_TrayWnd` to be topmost when the icon is clicked, so now we do that.
  - The volume menu extra will now only appear for users on Windows 10 with Cairo running as shell, due to the UWP popup of the native icon being unusable in this configuration.
- Set HIWORD of v4 notify icon window messages to icon `UID`
  - This fixes Avast apps (#351) and the network popup on Windows versions prior to 10
  - Also switched from using `PostMessage` to `SendNotifyMessage` to better match Explorer behavior