### PR TITLE
Stop manually focusing tray icons; seems to do more harm than good now

### DIFF
--- a/Cairo Desktop/CairoDesktop.WindowsTray/NotifyIcon.cs
+++ b/Cairo Desktop/CairoDesktop.WindowsTray/NotifyIcon.cs
@@ -338,8 +338,6 @@ namespace CairoDesktop.WindowsTray
 
                 _lastRClick = DateTime.Now;
             }
-
-            SetForegroundWindow(HWnd);
         }
 
         private uint GetMessageHiWord()


### PR DESCRIPTION
I think this was wallpapering over another issue that has since been fixed in the tray-compat branch, and now as a result having this is actually regressing things. I haven't seen any negative effects from removing this.