### PR TITLE
Fix tray focusing properly

### DIFF
--- a/Cairo Desktop/CairoDesktop.WindowsTray/NotifyIcon.cs
+++ b/Cairo Desktop/CairoDesktop.WindowsTray/NotifyIcon.cs
@@ -300,8 +300,9 @@ namespace CairoDesktop.WindowsTray
         {
             CairoLogger.Instance.Debug(string.Format("{0} mouse button clicked icon: {1}", button.ToString(), Title));
 
-            // ensure our Shell_TrayWnd is focused so that menus go away after clicking outside
+            // ensure focus so that menus go away after clicking outside
             SetForegroundWindow(NotificationArea.Instance.Handle);
+            SetForegroundWindow(HWnd);
 
             uint wparam = GetMessageWParam(mouse);
             uint hiWord = GetMessageHiWord();

--- a/Cairo Desktop/CairoDesktop.WindowsTray/NotifyIcon.cs
+++ b/Cairo Desktop/CairoDesktop.WindowsTray/NotifyIcon.cs
@@ -303,6 +303,8 @@ namespace CairoDesktop.WindowsTray
             // ensure our Shell_TrayWnd is topmost, which some icons require
             TrayService.Instance.MakeTrayTopmost();
 
+            SetForegroundWindow(HWnd);
+
             uint wparam = GetMessageWParam(mouse);
             uint hiWord = GetMessageHiWord();
 

--- a/Cairo Desktop/CairoDesktop.WindowsTray/NotifyIcon.cs
+++ b/Cairo Desktop/CairoDesktop.WindowsTray/NotifyIcon.cs
@@ -300,10 +300,8 @@ namespace CairoDesktop.WindowsTray
         {
             CairoLogger.Instance.Debug(string.Format("{0} mouse button clicked icon: {1}", button.ToString(), Title));
 
-            // ensure our Shell_TrayWnd is topmost, which some icons require
-            TrayService.Instance.MakeTrayTopmost();
-
-            SetForegroundWindow(HWnd);
+            // ensure our Shell_TrayWnd is focused so that menus go away after clicking outside
+            SetForegroundWindow(NotificationArea.Instance.Handle);
 
             uint wparam = GetMessageWParam(mouse);
             uint hiWord = GetMessageHiWord();

--- a/Cairo Desktop/CairoDesktop.WindowsTray/TrayService.cs
+++ b/Cairo Desktop/CairoDesktop.WindowsTray/TrayService.cs
@@ -356,7 +356,7 @@ namespace CairoDesktop.WindowsTray
             }
         }
 
-        public void MakeTrayTopmost()
+        private void MakeTrayTopmost()
         {
             if (HwndTray != IntPtr.Zero)
             {


### PR DESCRIPTION
My previous PR regarding this forgot that we need to focus _something_, so now instead of making Shell_TrayWnd topmost, focus it. 2 birds, 1 LOC.