### PR TITLE
Add support for HideSCAVolume group policy

### DIFF
--- a/Cairo Desktop/CairoDesktop.Common/Helpers/GroupPolicyManager.cs
+++ b/Cairo Desktop/CairoDesktop.Common/Helpers/GroupPolicyManager.cs
@@ -5,6 +5,8 @@ namespace CairoDesktop.Common.Helpers
 {
     public sealed class GroupPolicyManager : SingletonObject<GroupPolicyManager>
     {
+        const string ExplorerPolicyKey = @"Software\Microsoft\Windows\CurrentVersion\Policies\Explorer";
+
         private GroupPolicyManager()
         {
         }
@@ -29,20 +31,36 @@ namespace CairoDesktop.Common.Helpers
         /// Admx: Desktop.admx
         /// Documentation: https://gpsearch.azurewebsites.net/#146
         /// </remarks>
-        public bool NoDesktop
+        public bool NoDesktop =>
+            GetRegistryValue<int>(Registry.CurrentUser, ExplorerPolicyKey, "NoDesktop") == 1;
+
+        /// <summary>
+        /// This policy setting allows you to remove the volume control icon from the system control area.
+        /// 
+        /// If you enable this policy setting, the volume control icon is not displayed in the system notification area.
+        ///
+        /// If you disable or do not configure this policy setting, the volume control icon is displayed in the system notification area.
+        /// </summary>
+        /// <remarks>
+        /// Policy: Remove the volume control icon
+        /// Category Path: User Configuration\Administrative Templates\Start Menu and Taskbar\
+        /// Supported On: At least Microsoft Windows Vista
+        /// Registry Key: HKCU\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer
+        /// Value: HideSCAVolume
+        /// Admx: Taskbar.admx
+        /// Documentation: https://gpsearch.azurewebsites.net/#4677
+        /// </remarks>
+        public bool HideScaVolume =>
+            GetRegistryValue<int>(Registry.CurrentUser, ExplorerPolicyKey, "HideSCAVolume") == 1;
+
+        private static T GetRegistryValue<T>(RegistryKey key, string subKey, string valueName)
         {
-            get
-            {
-                bool result = false;
-
-                var reg = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Policies\Explorer");
-                object val = reg?.GetValue("NoDesktop", 0);
-                if (val is int noDesktopValue)
-                    if (noDesktopValue == 1)
-                        result = true;
-
-                return result;
-            }
+            var reg = key?.OpenSubKey(subKey);
+            object val = reg?.GetValue(valueName, default);
+            if (val is T value)
+                return value;
+            
+            return default;
         }
     }
 }

--- a/Cairo Desktop/CairoDesktop.WindowsTray/NotificationArea.cs
+++ b/Cairo Desktop/CairoDesktop.WindowsTray/NotificationArea.cs
@@ -6,6 +6,7 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Windows;
 using System.Windows.Data;
+using CairoDesktop.Common.Helpers;
 using static CairoDesktop.Interop.NativeMethods;
 
 namespace CairoDesktop.WindowsTray
@@ -196,7 +197,7 @@ namespace CairoDesktop.WindowsTray
                         bool exists = false;
 
                         // hide icons while we are shell which require UWP support & we have a separate implementation for
-                        if (nicData.guidItem == new Guid(VOLUME_GUID) && Shell.IsCairoRunningAsShell && Shell.IsWindows10OrBetter)
+                        if (nicData.guidItem == new Guid(VOLUME_GUID) && ((Shell.IsCairoRunningAsShell && Shell.IsWindows10OrBetter) || GroupPolicyManager.Instance.HideScaVolume))
                             return false;
 
                         foreach (NotifyIcon ti in TrayIcons)


### PR DESCRIPTION
(#484) Now provides the ability to hide the Windows native volume control via group policy

Also refactored the registry logic in GroupPolicyManager to be generic and reusable