### PR TITLE
Add support for enabling/disabling menubar

### DIFF
--- a/Cairo Desktop/Cairo Desktop/Startup.cs
+++ b/Cairo Desktop/Cairo Desktop/Startup.cs
@@ -54,15 +54,18 @@ namespace CairoDesktop
             #endregion
 
             App app = new App();
-            app.InitializeComponent();  // This sets up the Unhandled Exception stuff... 
+            app.InitializeComponent();  // This sets up the Unhandled Exception stuff...
 
             setTheme(app);
 
             // Future: This should be moved to whatever plugin is responsible for MenuBar stuff
-            MenuBar initialMenuBar = new MenuBar(System.Windows.Forms.Screen.PrimaryScreen);
-            app.MainWindow = initialMenuBar;
-            WindowManager.Instance.MenuBarWindows.Add(initialMenuBar);
-            initialMenuBar.Show();
+            if (Settings.Instance.EnableMenuBar)
+            {
+              MenuBar initialMenuBar = new MenuBar(System.Windows.Forms.Screen.PrimaryScreen);
+              app.MainWindow = initialMenuBar;
+              WindowManager.Instance.MenuBarWindows.Add(initialMenuBar);
+              initialMenuBar.Show();
+            }
 
             // Future: This should be moved to whatever plugin is responsible for Taskbar stuff
             if (Settings.Instance.EnableTaskbar)

--- a/Cairo Desktop/CairoDesktop.Configuration/Properties/Settings.settings
+++ b/Cairo Desktop/CairoDesktop.Configuration/Properties/Settings.settings
@@ -77,6 +77,9 @@
     <Setting Name="FoldersOpenDesktopOverlay" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="EnableMenuBar" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
     <Setting Name="EnableMenuBarBlur" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>

--- a/Cairo Desktop/CairoDesktop.Configuration/Settings.cs
+++ b/Cairo Desktop/CairoDesktop.Configuration/Settings.cs
@@ -483,6 +483,21 @@ namespace CairoDesktop.Configuration
             }
         }
 
+        public bool EnableMenuBar
+        {
+            get
+            {
+                return cairoSettings.EnableMenuBar;
+            }
+            set
+            {
+                if (cairoSettings.EnableMenuBar != value)
+                {
+                    cairoSettings.EnableMenuBar = value;
+                }
+            }
+        }
+
         public bool EnableMenuBarShadow
         {
             get


### PR DESCRIPTION
We have a use-case that requires giving the user limited control over where they navigate within the shell. This allows a user to specify whether they want the default Cairo Menubar enabled on startup.