### PR TITLE
Add support for disabling menu bar via settings.

### DIFF
--- a/Cairo Desktop/Cairo Desktop/Startup.cs
+++ b/Cairo Desktop/Cairo Desktop/Startup.cs
@@ -59,10 +59,13 @@ namespace CairoDesktop
             setTheme(app);
 
             // Future: This should be moved to whatever plugin is responsible for MenuBar stuff
-            MenuBar initialMenuBar = new MenuBar(System.Windows.Forms.Screen.PrimaryScreen);
-            app.MainWindow = initialMenuBar;
-            WindowManager.Instance.MenuBarWindows.Add(initialMenuBar);
-            initialMenuBar.Show();
+            if (Settings.Instance.EnableMenuBar)
+            {
+                MenuBar initialMenuBar = new MenuBar(System.Windows.Forms.Screen.PrimaryScreen);
+                app.MainWindow = initialMenuBar;
+                WindowManager.Instance.MenuBarWindows.Add(initialMenuBar);
+                initialMenuBar.Show();
+            }
 
             // Future: This should be moved to whatever plugin is responsible for Taskbar stuff
             if (Settings.Instance.EnableTaskbar)

--- a/Cairo Desktop/CairoDesktop.Configuration/Properties/Settings.Designer.cs
+++ b/Cairo Desktop/CairoDesktop.Configuration/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace CairoDesktop.Configuration.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.7.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.8.1.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -561,6 +561,18 @@ namespace CairoDesktop.Configuration.Properties {
             }
             set {
                 this["EnableMenuExtraSearch"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool EnableMenuBar {
+            get {
+                return ((bool)(this["EnableMenuBar"]));
+            }
+            set {
+                this["EnableMenuBar"] = value;
             }
         }
     }

--- a/Cairo Desktop/CairoDesktop.Configuration/Properties/Settings.settings
+++ b/Cairo Desktop/CairoDesktop.Configuration/Properties/Settings.settings
@@ -137,5 +137,8 @@
     <Setting Name="EnableMenuExtraSearch" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="EnableMenuBar" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Cairo Desktop/CairoDesktop.Configuration/Settings.cs
+++ b/Cairo Desktop/CairoDesktop.Configuration/Settings.cs
@@ -483,6 +483,21 @@ namespace CairoDesktop.Configuration
             }
         }
 
+        public bool EnableMenuBar
+        {
+            get
+            {
+                return cairoSettings.EnableMenuBar;
+            }
+            set
+            {
+                if (cairoSettings.EnableMenuBar != value)
+                {
+                    cairoSettings.EnableMenuBar = value;
+                }
+            }
+        }
+
         public bool EnableMenuBarShadow
         {
             get

--- a/Cairo Desktop/CairoDesktop.Configuration/app.config
+++ b/Cairo Desktop/CairoDesktop.Configuration/app.config
@@ -142,6 +142,9 @@
       <setting name="EnableMenuExtraSearch" serializeAs="String">
         <value>True</value>
       </setting>
+      <setting name="EnableMenuBar" serializeAs="String">
+        <value>True</value>
+      </setting>
     </CairoDesktop.Configuration.Properties.Settings>
   </userSettings>
   <startup>


### PR DESCRIPTION
This adds the ability for a user to completely disable the menu bar via editing the settings directly. This is to support a use-case that requires disabling most of the Cairo UI before instantiating alternate UI components.