### PR TITLE
Hide taskbar labels (issue #510)

### DIFF
--- a/Cairo Desktop/Cairo Desktop/CairoSettingsWindow.xaml
+++ b/Cairo Desktop/Cairo Desktop/CairoSettingsWindow.xaml
@@ -737,6 +737,10 @@
                             </RadioButton>
                         </StackPanel>
                     </StackPanel>
+                    <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=HideTaskbarLabels, UpdateSourceTrigger=PropertyChanged}"
+                              Name="chkHideTaskbarLabels">
+                        <Label Content="{Binding Path=(l10n:DisplayString.sSettings_Taskbar_HideLabels)}" />
+                    </CheckBox>
                     <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=EnableTaskbarThumbnails, UpdateSourceTrigger=PropertyChanged}"
                               Name="chkEnableTaskbarThumbnails">
                         <Label Content="{Binding Path=(l10n:DisplayString.sSettings_Taskbar_EnableThumbnails)}" />

--- a/Cairo Desktop/Cairo Desktop/CairoSettingsWindow.xaml
+++ b/Cairo Desktop/Cairo Desktop/CairoSettingsWindow.xaml
@@ -737,9 +737,9 @@
                             </RadioButton>
                         </StackPanel>
                     </StackPanel>
-                    <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=HideTaskbarLabels, UpdateSourceTrigger=PropertyChanged}"
+                    <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=ShowTaskbarLabels, UpdateSourceTrigger=PropertyChanged}"
                               Name="chkHideTaskbarLabels">
-                        <Label Content="{Binding Path=(l10n:DisplayString.sSettings_Taskbar_HideLabels)}" />
+                        <Label Content="{Binding Path=(l10n:DisplayString.sSettings_Taskbar_ShowLabels)}" />
                     </CheckBox>
                     <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=EnableTaskbarThumbnails, UpdateSourceTrigger=PropertyChanged}"
                               Name="chkEnableTaskbarThumbnails">

--- a/Cairo Desktop/Cairo Desktop/CairoSettingsWindow.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/CairoSettingsWindow.xaml.cs
@@ -67,13 +67,13 @@ namespace CairoDesktop
                     break;
             }
 
-            switch ((IconSize)Settings.Instance.DesktopIconSize)
+            switch ((IconSize.Sizes)Settings.Instance.DesktopIconSize)
             {
-                case IconSize.Large:
+                case IconSize.Sizes.Large:
                     radDesktopIconSize0.IsChecked = true;
                     radDesktopIconSize2.IsChecked = false;
                     break;
-                case IconSize.ExtraLarge:
+                case IconSize.Sizes.ExtraLarge:
                     radDesktopIconSize0.IsChecked = false;
                     radDesktopIconSize2.IsChecked = true;
                     break;
@@ -130,19 +130,19 @@ namespace CairoDesktop
                     break;
             }
 
-            switch ((IconSize)Settings.Instance.TaskbarIconSize)
+            switch ((IconSize.Sizes)Settings.Instance.TaskbarIconSize)
             {
-                case IconSize.Large:
+                case IconSize.Sizes.Large:
                     radTaskbarSize0.IsChecked = true;
                     radTaskbarSize10.IsChecked = false;
                     radTaskbarSize1.IsChecked = false;
                     break;
-                case IconSize.Small:
+                case IconSize.Sizes.Small:
                     radTaskbarSize0.IsChecked = false;
                     radTaskbarSize10.IsChecked = false;
                     radTaskbarSize1.IsChecked = true;
                     break;
-                case IconSize.Medium:
+                case IconSize.Sizes.Medium:
                     radTaskbarSize0.IsChecked = false;
                     radTaskbarSize10.IsChecked = true;
                     radTaskbarSize1.IsChecked = false;
@@ -619,17 +619,17 @@ namespace CairoDesktop
 
         private void radTaskbarSize0_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.TaskbarIconSize = (int)IconSize.Large;
+            Settings.Instance.TaskbarIconSize = (int)IconSize.Sizes.Large;
         }
 
         private void radTaskbarSize1_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.TaskbarIconSize = (int)IconSize.Small;
+            Settings.Instance.TaskbarIconSize = (int)IconSize.Sizes.Small;
         }
 
         private void radTaskbarSize10_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.TaskbarIconSize = (int)IconSize.Medium;
+            Settings.Instance.TaskbarIconSize = (int)IconSize.Sizes.Medium;
         }
 
         private void radTaskbarMiddleClick0_Click(object sender, RoutedEventArgs e)
@@ -654,12 +654,12 @@ namespace CairoDesktop
 
         private void radDesktopIconSize0_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.DesktopIconSize = (int)IconSize.Large;
+            Settings.Instance.DesktopIconSize = (int)IconSize.Sizes.Large;
         }
 
         private void radDesktopIconSize2_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.DesktopIconSize = (int)IconSize.ExtraLarge;
+            Settings.Instance.DesktopIconSize = (int)IconSize.Sizes.ExtraLarge;
         }
 
         private void radTrayMode0_Click(object sender, RoutedEventArgs e)

--- a/Cairo Desktop/Cairo Desktop/Icon.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/Icon.xaml.cs
@@ -141,10 +141,10 @@ namespace CairoDesktop
                 bdrFilename.SetValue(DockPanel.DockProperty, Dock.Bottom);
             }
 
-            if (Settings.Instance.DesktopIconSize == (int)IconSize.ExtraLarge)
+            if (Settings.Instance.DesktopIconSize == (int)IconSize.Sizes.ExtraLarge)
             {
-                imgIcon.Width = 48;
-                imgIcon.Height = 48;
+                imgIcon.Width = IconSize.GetSize(IconSize.Sizes.ExtraLarge);
+                imgIcon.Height = IconSize.GetSize(IconSize.Sizes.ExtraLarge);
                 Binding iconBinding = new Binding("LargeIcon");
                 iconBinding.Mode = BindingMode.OneWay;
                 iconBinding.FallbackValue = Application.Current.FindResource("NullIcon") as BitmapImage;
@@ -153,8 +153,8 @@ namespace CairoDesktop
             }
             else
             {
-                imgIcon.Width = 32;
-                imgIcon.Height = 32;
+                imgIcon.Width = IconSize.GetSize(IconSize.Sizes.Large);
+                imgIcon.Height = IconSize.GetSize(IconSize.Sizes.Large);
                 Binding iconBinding = new Binding("Icon");
                 iconBinding.Mode = BindingMode.OneWay;
                 iconBinding.FallbackValue = Application.Current.FindResource("NullIcon") as BitmapImage;

--- a/Cairo Desktop/Cairo Desktop/QuickLaunchButton.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/QuickLaunchButton.xaml.cs
@@ -45,21 +45,8 @@ namespace CairoDesktop
 
         private void setIconSize()
         {
-            switch ((IconSize)Settings.Instance.TaskbarIconSize)
-            {
-                case IconSize.Large:
-                    imgIcon.Width = 32;
-                    imgIcon.Height = 32;
-                    break;
-                case IconSize.Medium:
-                    imgIcon.Width = 24;
-                    imgIcon.Height = 24;
-                    break;
-                default:
-                    imgIcon.Width = 16;
-                    imgIcon.Height = 16;
-                    break;
-            }
+            imgIcon.Width = IconSize.GetSize(Settings.Instance.TaskbarIconSize);
+            imgIcon.Height = IconSize.GetSize(Settings.Instance.TaskbarIconSize);
         }
 
         private void LaunchProgram(object sender, RoutedEventArgs e)

--- a/Cairo Desktop/Cairo Desktop/TaskButton.xaml
+++ b/Cairo Desktop/Cairo Desktop/TaskButton.xaml
@@ -83,7 +83,7 @@
                 </MenuItem>
             </ContextMenu>
         </Button.ContextMenu>
-        <Grid x:Name="ButtonGrid">
+        <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />

--- a/Cairo Desktop/Cairo Desktop/TaskButton.xaml
+++ b/Cairo Desktop/Cairo Desktop/TaskButton.xaml
@@ -83,7 +83,7 @@
                 </MenuItem>
             </ContextMenu>
         </Button.ContextMenu>
-        <Grid>
+        <Grid x:Name="ButtonGrid">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />

--- a/Cairo Desktop/Cairo Desktop/TaskButton.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/TaskButton.xaml.cs
@@ -103,6 +103,7 @@ namespace CairoDesktop
 
             if (!ListMode)
             {
+                setLabelVisibility();
                 setIconSize();
                 setToolTip();
             }
@@ -141,6 +142,8 @@ namespace CairoDesktop
                         setToolTip();
                         break;
                     case "TaskbarIconSize":
+                    case "HideTaskbarLabels":
+                        setLabelVisibility();
                         setIconSize();
                         break;
                 }
@@ -167,25 +170,29 @@ namespace CairoDesktop
             }
         }
 
+        private void setLabelVisibility()
+        {
+            if (!ListMode)
+            {
+                if (Settings.Instance.HideTaskbarLabels)
+                {
+                    if (ButtonGrid.Children.Contains(WinTitle))
+                        ButtonGrid.Children.Remove(WinTitle);
+                }
+                else
+                {
+                    if (!ButtonGrid.Children.Contains(WinTitle))
+                        ButtonGrid.Children.Add(WinTitle);
+                }
+            }
+        }
+
         private void setIconSize()
         {
             if (!ListMode)
             {
-                switch ((IconSize)Settings.Instance.TaskbarIconSize)
-                {
-                    case IconSize.Large:
-                        imgIcon.Width = 32;
-                        imgIcon.Height = 32;
-                        break;
-                    case IconSize.Medium:
-                        imgIcon.Width = 24;
-                        imgIcon.Height = 24;
-                        break;
-                    default:
-                        imgIcon.Width = 16;
-                        imgIcon.Height = 16;
-                        break;
-                }
+                imgIcon.Width = IconSize.GetSize(Settings.Instance.TaskbarIconSize);
+                imgIcon.Height = IconSize.GetSize(Settings.Instance.TaskbarIconSize);
             }
         }
 

--- a/Cairo Desktop/Cairo Desktop/TaskButton.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/TaskButton.xaml.cs
@@ -142,7 +142,7 @@ namespace CairoDesktop
                         setToolTip();
                         break;
                     case "TaskbarIconSize":
-                    case "HideTaskbarLabels":
+                    case "ShowTaskbarLabels":
                         setLabelVisibility();
                         setIconSize();
                         break;
@@ -174,16 +174,7 @@ namespace CairoDesktop
         {
             if (!ListMode)
             {
-                if (Settings.Instance.HideTaskbarLabels)
-                {
-                    if (ButtonGrid.Children.Contains(WinTitle))
-                        ButtonGrid.Children.Remove(WinTitle);
-                }
-                else
-                {
-                    if (!ButtonGrid.Children.Contains(WinTitle))
-                        ButtonGrid.Children.Add(WinTitle);
-                }
+                WinTitle.Visibility = Settings.Instance.ShowTaskbarLabels ? Visibility.Visible : Visibility.Collapsed;
             }
         }
 

--- a/Cairo Desktop/Cairo Desktop/Taskbar.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/Taskbar.xaml.cs
@@ -154,7 +154,7 @@ namespace CairoDesktop
                     break;
             }
 
-            baseButtonWidth = Settings.Instance.HideTaskbarLabels ? getButtonWidth() : (Settings.Instance.TaskbarButtonWidth + addToSize);
+            baseButtonWidth = (Settings.Instance.ShowTaskbarLabels ? Settings.Instance.TaskbarButtonWidth : Settings.Instance.TaskbarButtonHeight) + addToSize;
             Height = Settings.Instance.TaskbarButtonHeight + addToSize;
             desiredHeight = Height;
             Top = getDesiredTopPosition();
@@ -163,27 +163,6 @@ namespace CairoDesktop
                 bdrTaskListPopup.Margin = new Thickness(5, Top + Height - 1, 5, 11);
             else
                 bdrTaskListPopup.Margin = new Thickness(5, 0, 5, (Screen.Bounds.Bottom / dpiScale) - Top - 1);
-        }
-
-        private int getButtonWidth()
-        {
-            int adjustment = 0;
-
-            switch (Settings.Instance.TaskbarIconSize)
-            {
-                case (int)IconSize.Sizes.Large:
-                    adjustment = -2;
-                    break;
-                case (int)IconSize.Sizes.Small:
-                    adjustment = +2;
-                    break;
-            }
-
-            //Get size + adjusment
-            int Width = IconSize.GetSize(Settings.Instance.TaskbarIconSize) + adjustment;
-
-            //Add some extra room based on the icon width
-            return Convert.ToInt32(Width + (Width * 0.5));
         }
 
         private void setTaskbarWidthMode()
@@ -262,7 +241,7 @@ namespace CairoDesktop
             {
                 switch (e.PropertyName)
                 {
-                    case "HideTaskbarLabels":
+                    case "ShowTaskbarLabels":
                     case "TaskbarIconSize":
                         setTaskbarSize();
                         SetScreenPosition();

--- a/Cairo Desktop/Cairo Desktop/Taskbar.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/Taskbar.xaml.cs
@@ -116,7 +116,7 @@ namespace CairoDesktop
                 bdrTaskView.Visibility = Visibility.Visible;
             else
                 TasksList2.Margin = new Thickness(0, -3, 0, -3);
-            
+
             setTaskbarSize();
             setTaskbarWidthMode();
         }
@@ -141,12 +141,12 @@ namespace CairoDesktop
 
         private void setTaskbarSize()
         {
-            switch ((IconSize)Settings.Instance.TaskbarIconSize)
+            switch ((IconSize.Sizes)Settings.Instance.TaskbarIconSize)
             {
-                case IconSize.Large:
+                case IconSize.Sizes.Large:
                     addToSize = 16;
                     break;
-                case IconSize.Medium:
+                case IconSize.Sizes.Medium:
                     addToSize = 8;
                     break;
                 default:
@@ -154,8 +154,8 @@ namespace CairoDesktop
                     break;
             }
 
-            baseButtonWidth = 140 + addToSize;
-            Height = 29 + addToSize;
+            baseButtonWidth = Settings.Instance.HideTaskbarLabels ? getButtonIconWidth() : (Settings.Instance.TaskbarButtonWidth + addToSize);
+            Height = Settings.Instance.TaskbarButtonHeight + addToSize;
             desiredHeight = Height;
             Top = getDesiredTopPosition();
 
@@ -163,6 +163,27 @@ namespace CairoDesktop
                 bdrTaskListPopup.Margin = new Thickness(5, Top + Height - 1, 5, 11);
             else
                 bdrTaskListPopup.Margin = new Thickness(5, 0, 5, (Screen.Bounds.Bottom / dpiScale) - Top - 1);
+        }
+
+        private int getButtonIconWidth()
+        {
+            int adjustment = 0;
+
+            switch (Settings.Instance.TaskbarIconSize)
+            {
+                case (int)IconSize.Sizes.Large:
+                    adjustment = -2;
+                    break;
+                case (int)IconSize.Sizes.Small:
+                    adjustment = +2;
+                    break;
+            }
+
+            //Get size + adjusment
+            int Width = IconSize.GetSize(Settings.Instance.TaskbarIconSize) + adjustment;
+
+            //Add some extra room based on the icon width
+            return Convert.ToInt32(Width + (Width * 0.5));
         }
 
         private void setTaskbarWidthMode()
@@ -241,6 +262,7 @@ namespace CairoDesktop
             {
                 switch (e.PropertyName)
                 {
+                    case "HideTaskbarLabels":
                     case "TaskbarIconSize":
                         setTaskbarSize();
                         SetScreenPosition();
@@ -502,7 +524,7 @@ namespace CairoDesktop
         {
             Shell.ShowRunDialog();
         }
-        
+
         private void OpenTaskManager(object sender, RoutedEventArgs e)
         {
             Shell.StartTaskManager();

--- a/Cairo Desktop/Cairo Desktop/Taskbar.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/Taskbar.xaml.cs
@@ -154,7 +154,7 @@ namespace CairoDesktop
                     break;
             }
 
-            baseButtonWidth = Settings.Instance.HideTaskbarLabels ? getButtonIconWidth() : (Settings.Instance.TaskbarButtonWidth + addToSize);
+            baseButtonWidth = Settings.Instance.HideTaskbarLabels ? getButtonWidth() : (Settings.Instance.TaskbarButtonWidth + addToSize);
             Height = Settings.Instance.TaskbarButtonHeight + addToSize;
             desiredHeight = Height;
             Top = getDesiredTopPosition();
@@ -165,7 +165,7 @@ namespace CairoDesktop
                 bdrTaskListPopup.Margin = new Thickness(5, 0, 5, (Screen.Bounds.Bottom / dpiScale) - Top - 1);
         }
 
-        private int getButtonIconWidth()
+        private int getButtonWidth()
         {
             int adjustment = 0;
 

--- a/Cairo Desktop/CairoDesktop.AppGrabber/AppGrabber.cs
+++ b/Cairo Desktop/CairoDesktop.AppGrabber/AppGrabber.cs
@@ -409,7 +409,7 @@ namespace CairoDesktop.AppGrabber
             if (app != null)
             {
                 if (app.IsStoreApp)
-                    CairoMessage.Show(Localization.DisplayString.sProgramsMenu_UWPInfo, app.Name, app.GetIconImageSource(IconSize.Jumbo, false), true);
+                    CairoMessage.Show(Localization.DisplayString.sProgramsMenu_UWPInfo, app.Name, app.GetIconImageSource(IconSize.Sizes.Jumbo, false), true);
                 else
                     Shell.ShowFileProperties(app.Path);
             }

--- a/Cairo Desktop/CairoDesktop.AppGrabber/ApplicationInfo.cs
+++ b/Cairo Desktop/CairoDesktop.AppGrabber/ApplicationInfo.cs
@@ -293,9 +293,9 @@ namespace CairoDesktop.AppGrabber
 
         private ImageSource GetAssociatedIcon()
         {
-            IconSize size = IconSize.Small;
-            if (Category != null && Category.Type == AppCategoryType.QuickLaunch && (IconSize)Configuration.Settings.Instance.TaskbarIconSize != IconSize.Small)
-                size = IconSize.Large;
+            IconSize.Sizes size = IconSize.Sizes.Small;
+            if (Category != null && Category.Type == AppCategoryType.QuickLaunch && (IconSize.Sizes)Configuration.Settings.Instance.TaskbarIconSize != IconSize.Sizes.Small)
+                size = IconSize.Sizes.Large;
 
             return GetIconImageSource(size, true);
         }
@@ -303,7 +303,7 @@ namespace CairoDesktop.AppGrabber
         /// <summary>
         /// Gets an ImageSource object representing the associated icon of a file.
         /// </summary>
-        public ImageSource GetIconImageSource(IconSize size, bool useCache)
+        public ImageSource GetIconImageSource(IconSize.Sizes size, bool useCache)
         {
             if (IsStoreApp)
             {

--- a/Cairo Desktop/CairoDesktop.Common/IconImageConverter.cs
+++ b/Cairo Desktop/CairoDesktop.Common/IconImageConverter.cs
@@ -17,7 +17,7 @@ namespace CairoDesktop.Common
         /// <param name="filename">The filename of the file to query the Icon for.</param>
         /// <param name="size">0 = 32px, 1 = 16px, 2 = 48px</param>
         /// <returns>The icon as an ImageSource, otherwise a default image.</returns>
-        public static ImageSource GetImageFromAssociatedIcon(string filename, IconSize size) 
+        public static ImageSource GetImageFromAssociatedIcon(string filename, IconSize.Sizes size) 
         {
             BitmapSource bs = null;
             

--- a/Cairo Desktop/CairoDesktop.Common/IconSize.cs
+++ b/Cairo Desktop/CairoDesktop.Common/IconSize.cs
@@ -1,11 +1,51 @@
-﻿namespace CairoDesktop.Common
+﻿using System;
+
+namespace CairoDesktop.Common
 {
-    public enum IconSize: int
+    public class IconSize
     {
-        Large = 0,
-        Small = 1,
-        Medium = 10,
-        ExtraLarge = 2,
-        Jumbo = 4
+        public enum Sizes : int
+        {
+            ///<summary>32 pixels</summary>
+            Large = 0,
+            ///<summary>16 pixels</summary>
+            Small = 1,
+            ///<summary>24 pixels</summary>
+            Medium = 10,
+            ///<summary>48 pixels</summary>
+            ExtraLarge = 2,
+            ///<summary>96 pixels</summary>
+            Jumbo = 4
+        }
+
+        public static Sizes ParseSize(int size)
+        {
+            if (Enum.IsDefined(typeof(Sizes), size)) return (Sizes)size;
+            else return Sizes.Small;
+        }
+
+        public static int GetSize(int size)
+        {
+            return GetSize(ParseSize(size));
+        }
+
+        public static int GetSize(Sizes size)
+        {
+            switch (size)
+            {
+                case Sizes.Large:
+                    return 32;
+                case Sizes.Small:
+                    return 16;
+                case Sizes.Medium:
+                    return 24;
+                case Sizes.ExtraLarge:
+                    return 48;
+                case Sizes.Jumbo:
+                    return 96;
+                default:
+                    return 16;
+            }
+        }
     }
 }

--- a/Cairo Desktop/CairoDesktop.Common/SearchHelper.cs
+++ b/Cairo Desktop/CairoDesktop.Common/SearchHelper.cs
@@ -174,7 +174,7 @@ namespace CairoDesktop.Common
                     Task.Factory.StartNew(() =>
                     {
                         string iconPath = Path.Substring(Path.IndexOf(':') + 1).Replace("/", "\\");
-                        Icon = IconImageConverter.GetImageFromAssociatedIcon(iconPath, IconSize.Large);
+                        Icon = IconImageConverter.GetImageFromAssociatedIcon(iconPath, IconSize.Sizes.Large);
                         _iconLoading = false;
                     }, CancellationToken.None, TaskCreationOptions.None, Interop.Shell.IconScheduler);
                 }

--- a/Cairo Desktop/CairoDesktop.Common/SystemFile.cs
+++ b/Cairo Desktop/CairoDesktop.Common/SystemFile.cs
@@ -142,7 +142,7 @@ namespace CairoDesktop.Common
 
                     Task.Factory.StartNew(() =>
                     {
-                        Icon = GetDisplayIcon(IconSize.Large);
+                        Icon = GetDisplayIcon(IconSize.Sizes.Large);
                         Icon.Freeze();
                         _iconLoading = false;
                     }, CancellationToken.None, TaskCreationOptions.None, Interop.Shell.IconScheduler);
@@ -171,7 +171,7 @@ namespace CairoDesktop.Common
 
                     Task.Factory.StartNew(() =>
                     {
-                        LargeIcon = GetDisplayIcon(IconSize.ExtraLarge);
+                        LargeIcon = GetDisplayIcon(IconSize.Sizes.ExtraLarge);
                         LargeIcon.Freeze();
                         _iconLargeLoading = false;
                     }, CancellationToken.None, TaskCreationOptions.None, Interop.Shell.IconScheduler);
@@ -322,7 +322,7 @@ namespace CairoDesktop.Common
         /// Retrieves the display icon of the file.
         /// If the file is an image then it will return the image its self (e.g. preview).
         /// </summary>
-        private ImageSource GetDisplayIcon(IconSize size)
+        private ImageSource GetDisplayIcon(IconSize.Sizes size)
         {
             if (Interop.Shell.Exists(FullName))
             {
@@ -336,10 +336,10 @@ namespace CairoDesktop.Common
                             img.BeginInit();
                             img.CacheOption = BitmapCacheOption.OnLoad;
                             img.UriSource = new Uri(FullName);
-                            int dSize = 32;
+                            int dSize = IconSize.GetSize(IconSize.Sizes.Large);
 
-                            if (size == IconSize.ExtraLarge)
-                                dSize = 48;
+                            if (size == IconSize.Sizes.ExtraLarge)
+                                dSize = IconSize.GetSize(IconSize.Sizes.ExtraLarge);
 
                             Interop.Shell.TransformToPixels(dSize, dSize, out dSize, out dSize);
                             img.DecodePixelWidth = dSize;
@@ -370,7 +370,7 @@ namespace CairoDesktop.Common
             }
         }
 
-        private ImageSource handleThumbnailError(IconSize size)
+        private ImageSource handleThumbnailError(IconSize.Sizes size)
         {
             if (_imageReloadAttempts < MAX_IMAGE_RELOAD_ATTEMPTS)
             {

--- a/Cairo Desktop/CairoDesktop.Configuration/Properties/Settings.Designer.cs
+++ b/Cairo Desktop/CairoDesktop.Configuration/Properties/Settings.Designer.cs
@@ -575,5 +575,41 @@ namespace CairoDesktop.Configuration.Properties {
                 this["EnableMenuBar"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool HideTaskbarLabels {
+            get {
+                return ((bool)(this["HideTaskbarLabels"]));
+            }
+            set {
+                this["HideTaskbarLabels"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("140")]
+        public int TaskbarButtonWidth {
+            get {
+                return ((int)(this["TaskbarButtonWidth"]));
+            }
+            set {
+                this["TaskbarButtonWidth"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("29")]
+        public int TaskbarButtonHeight {
+            get {
+                return ((int)(this["TaskbarButtonHeight"]));
+            }
+            set {
+                this["TaskbarButtonHeight"] = value;
+            }
+        }
     }
 }

--- a/Cairo Desktop/CairoDesktop.Configuration/Properties/Settings.Designer.cs
+++ b/Cairo Desktop/CairoDesktop.Configuration/Properties/Settings.Designer.cs
@@ -578,13 +578,13 @@ namespace CairoDesktop.Configuration.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("False")]
-        public bool HideTaskbarLabels {
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool ShowTaskbarLabels {
             get {
-                return ((bool)(this["HideTaskbarLabels"]));
+                return ((bool)(this["ShowTaskbarLabels"]));
             }
             set {
-                this["HideTaskbarLabels"] = value;
+                this["ShowTaskbarLabels"] = value;
             }
         }
         

--- a/Cairo Desktop/CairoDesktop.Configuration/Properties/Settings.settings
+++ b/Cairo Desktop/CairoDesktop.Configuration/Properties/Settings.settings
@@ -140,8 +140,8 @@
     <Setting Name="EnableMenuBar" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
-    <Setting Name="HideTaskbarLabels" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">False</Value>
+    <Setting Name="ShowTaskbarLabels" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="TaskbarButtonWidth" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">140</Value>

--- a/Cairo Desktop/CairoDesktop.Configuration/Properties/Settings.settings
+++ b/Cairo Desktop/CairoDesktop.Configuration/Properties/Settings.settings
@@ -140,5 +140,14 @@
     <Setting Name="EnableMenuBar" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="HideTaskbarLabels" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="TaskbarButtonWidth" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">140</Value>
+    </Setting>
+    <Setting Name="TaskbarButtonHeight" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">29</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Cairo Desktop/CairoDesktop.Configuration/Settings.cs
+++ b/Cairo Desktop/CairoDesktop.Configuration/Settings.cs
@@ -406,6 +406,51 @@ namespace CairoDesktop.Configuration
             }
         }
 
+        public bool HideTaskbarLabels
+        {
+            get
+            {
+                return cairoSettings.HideTaskbarLabels;
+            }
+            set
+            {
+                if (cairoSettings.HideTaskbarLabels != value)
+                {
+                    cairoSettings.HideTaskbarLabels = value;
+                }
+            }
+        }
+
+        public int TaskbarButtonWidth
+        {
+            get
+            {
+                return cairoSettings.TaskbarButtonWidth;
+            }
+            set
+            {
+                if (cairoSettings.TaskbarButtonWidth != value)
+                {
+                    cairoSettings.TaskbarButtonWidth = value;
+                }
+            }
+        }
+
+        public int TaskbarButtonHeight
+        {
+            get
+            {
+                return cairoSettings.TaskbarButtonHeight;
+            }
+            set
+            {
+                if (cairoSettings.TaskbarButtonHeight != value)
+                {
+                    cairoSettings.TaskbarButtonHeight = value;
+                }
+            }
+        }
+
         public bool EnableTaskbarMultiMon
         {
             get

--- a/Cairo Desktop/CairoDesktop.Configuration/Settings.cs
+++ b/Cairo Desktop/CairoDesktop.Configuration/Settings.cs
@@ -406,17 +406,17 @@ namespace CairoDesktop.Configuration
             }
         }
 
-        public bool HideTaskbarLabels
+        public bool ShowTaskbarLabels
         {
             get
             {
-                return cairoSettings.HideTaskbarLabels;
+                return cairoSettings.ShowTaskbarLabels;
             }
             set
             {
-                if (cairoSettings.HideTaskbarLabels != value)
+                if (cairoSettings.ShowTaskbarLabels != value)
                 {
-                    cairoSettings.HideTaskbarLabels = value;
+                    cairoSettings.ShowTaskbarLabels = value;
                 }
             }
         }

--- a/Cairo Desktop/CairoDesktop.Configuration/app.config
+++ b/Cairo Desktop/CairoDesktop.Configuration/app.config
@@ -145,8 +145,8 @@
       <setting name="EnableMenuBar" serializeAs="String">
         <value>True</value>
       </setting>
-      <setting name="HideTaskbarLabels" serializeAs="String">
-        <value>False</value>
+      <setting name="ShowTaskbarLabels" serializeAs="String">
+        <value>True</value>
       </setting>
       <setting name="TaskbarButtonWidth" serializeAs="String">
         <value>140</value>

--- a/Cairo Desktop/CairoDesktop.Configuration/app.config
+++ b/Cairo Desktop/CairoDesktop.Configuration/app.config
@@ -145,6 +145,15 @@
       <setting name="EnableMenuBar" serializeAs="String">
         <value>True</value>
       </setting>
+      <setting name="HideTaskbarLabels" serializeAs="String">
+        <value>False</value>
+      </setting>
+      <setting name="TaskbarButtonWidth" serializeAs="String">
+        <value>140</value>
+      </setting>
+      <setting name="TaskbarButtonHeight" serializeAs="String">
+        <value>29</value>
+      </setting>
     </CairoDesktop.Configuration.Properties.Settings>
   </userSettings>
   <startup>

--- a/Cairo Desktop/CairoDesktop.Localization/DisplayString.cs
+++ b/Cairo Desktop/CairoDesktop.Localization/DisplayString.cs
@@ -554,7 +554,7 @@ namespace CairoDesktop.Localization
 
         public static string sSettings_Taskbar_MiddleClickCloseWindow => getString();
 
-        public static string sSettings_Taskbar_HideLabels => getString();
+        public static string sSettings_Taskbar_ShowLabels => getString();
 
         public static string sSettings_Taskbar_EnableThumbnails => getString();
 

--- a/Cairo Desktop/CairoDesktop.Localization/DisplayString.cs
+++ b/Cairo Desktop/CairoDesktop.Localization/DisplayString.cs
@@ -554,6 +554,8 @@ namespace CairoDesktop.Localization
 
         public static string sSettings_Taskbar_MiddleClickCloseWindow => getString();
 
+        public static string sSettings_Taskbar_HideLabels => getString();
+
         public static string sSettings_Taskbar_EnableThumbnails => getString();
 
         public static string sSettings_Advanced_LoggingLevel => getString();

--- a/Cairo Desktop/CairoDesktop.Localization/Language.cs
+++ b/Cairo Desktop/CairoDesktop.Localization/Language.cs
@@ -236,7 +236,7 @@ namespace CairoDesktop.Localization
             { "sSettings_Taskbar_MiddleClick", "Middle-click action:" },
             { "sSettings_Taskbar_MiddleClickNewWindow", "Open new window" },
             { "sSettings_Taskbar_MiddleClickCloseWindow", "Close window" },
-            { "sSettings_Taskbar_HideLabels", "Hide labels" },
+            { "sSettings_Taskbar_ShowLabels", "Show labels" },
             { "sSettings_Taskbar_EnableThumbnails", "Show window thumbnails" },
             { "sSettings_Advanced_LoggingLevel", "Logging level:" },
             { "sSettings_Advanced_Shell", "Shell" },

--- a/Cairo Desktop/CairoDesktop.Localization/Language.cs
+++ b/Cairo Desktop/CairoDesktop.Localization/Language.cs
@@ -236,6 +236,7 @@ namespace CairoDesktop.Localization
             { "sSettings_Taskbar_MiddleClick", "Middle-click action:" },
             { "sSettings_Taskbar_MiddleClickNewWindow", "Open new window" },
             { "sSettings_Taskbar_MiddleClickCloseWindow", "Close window" },
+            { "sSettings_Taskbar_HideLabels", "Hide labels" },
             { "sSettings_Taskbar_EnableThumbnails", "Show window thumbnails" },
             { "sSettings_Advanced_LoggingLevel", "Logging level:" },
             { "sSettings_Advanced_Shell", "Shell" },

--- a/Cairo Desktop/CairoDesktop.WindowsTasks/ApplicationWindow.cs
+++ b/Cairo Desktop/CairoDesktop.WindowsTasks/ApplicationWindow.cs
@@ -374,9 +374,9 @@ namespace CairoDesktop.WindowsTasks
                         uint WM_QUERYDRAGICON = (uint)NativeMethods.WM.QUERYDRAGICON;
                         int GCL_HICON = -14;
                         int GCL_HICONSM = -34;
-                        IconSize sizeSetting = (IconSize)Configuration.Settings.Instance.TaskbarIconSize;
+                        IconSize.Sizes sizeSetting = IconSize.ParseSize(Configuration.Settings.Instance.TaskbarIconSize);
 
-                        if (sizeSetting == IconSize.Small)
+                        if (sizeSetting == IconSize.Sizes.Small)
                         {
                             NativeMethods.SendMessageTimeout(Handle, WM_GETICON, 2, 0, 2, 1000, ref hIco);
                             if (hIco == IntPtr.Zero)
@@ -387,7 +387,7 @@ namespace CairoDesktop.WindowsTasks
                             NativeMethods.SendMessageTimeout(Handle, WM_GETICON, 1, 0, 2, 1000, ref hIco);
                         }
 
-                        if (hIco == IntPtr.Zero && sizeSetting == IconSize.Small)
+                        if (hIco == IntPtr.Zero && sizeSetting == IconSize.Sizes.Small)
                         {
                             if (!Environment.Is64BitProcess)
                                 hIco = NativeMethods.GetClassLong(Handle, GCL_HICONSM);
@@ -414,7 +414,7 @@ namespace CairoDesktop.WindowsTasks
                             if (Shell.Exists(WinFileName))
                             {
                                 int size = 1;
-                                if (sizeSetting != IconSize.Small)
+                                if (sizeSetting != IconSize.Sizes.Small)
                                     size = 0;
 
                                 hIco = Shell.GetIconByFilename(WinFileName, size);


### PR DESCRIPTION
Basically what the title says, the taskbar can get cluttered pretty quick with the labels. (issue #510)
I did some clean up on the hard coded icon sizes thought the solution, that explains why some many files were touched.
Gave it a shot here and it worked pretty well, let me know your thoughts.

![image](https://user-images.githubusercontent.com/25939765/103422187-e2533b00-4b7e-11eb-8758-b1729273f96c.png)
