### PR TITLE
Removed cyclic dependency between ThemeService and CairoApplication

### DIFF
--- a/Cairo Desktop/Cairo Desktop/CairoApplication.InitializationRoutines.cs
+++ b/Cairo Desktop/Cairo Desktop/CairoApplication.InitializationRoutines.cs
@@ -47,9 +47,7 @@ namespace CairoDesktop
 
         private void SetTheme()
         {
-            // TODO: Find a cleaner way to do this. We can't inject it to CairoApplication since it has a dependency on ICairoApplication.
-            // We could work around this using something similar to how WindowManager receives WindowServices, but that doesn't seem any better.
-            Host.Services.GetService<ThemeService>()?.SetThemeFromSettings();
+            _themeService.SetThemeFromSettings();
         }
 
         private void SetupWindowServices()

--- a/Cairo Desktop/Cairo Desktop/CairoApplication.InitializationRoutines.cs
+++ b/Cairo Desktop/Cairo Desktop/CairoApplication.InitializationRoutines.cs
@@ -47,7 +47,7 @@ namespace CairoDesktop
 
         private void SetTheme()
         {
-            _themeService.SetThemeFromSettings();
+            _themeService.SetThemeFromSettings(this);
         }
 
         private void SetupWindowServices()

--- a/Cairo Desktop/Cairo Desktop/CairoApplication.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/CairoApplication.xaml.cs
@@ -18,6 +18,7 @@ using System.Windows.Media;
 using System.Windows.Threading;
 using CairoDesktop.Infrastructure.Options;
 using CairoDesktop.Infrastructure.Services;
+using CairoDesktop.Services;
 using ManagedShell.Common.SupportingClasses; // Required for StartupRunner; excluded from debug builds
 
 namespace CairoDesktop
@@ -26,6 +27,7 @@ namespace CairoDesktop
     {
         private readonly ILogger<CairoApplication> _logger;
         private readonly IOptionsMonitor<CommandLineOptions> _options;
+        private readonly ThemeService _themeService;
         public new static CairoApplication Current => System.Windows.Application.Current as CairoApplication;
 
         // Parameter-less constructor required for WPF
@@ -33,9 +35,10 @@ namespace CairoDesktop
         {
         }
 
-        public CairoApplication(IHost host, ILogger<CairoApplication> logger, IOptionsMonitor<CommandLineOptions> options)
+        public CairoApplication(IHost host, Func<ICairoApplication, ThemeService> themeServiceFactory, ILogger<CairoApplication> logger, IOptionsMonitor<CommandLineOptions> options)
         {
             Host = host;
+            _themeService = themeServiceFactory(this);
             _logger = logger;
             _options = options;
 

--- a/Cairo Desktop/Cairo Desktop/CairoApplication.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/CairoApplication.xaml.cs
@@ -35,10 +35,10 @@ namespace CairoDesktop
         {
         }
 
-        public CairoApplication(IHost host, Func<ICairoApplication, ThemeService> themeServiceFactory, ILogger<CairoApplication> logger, IOptionsMonitor<CommandLineOptions> options)
+        public CairoApplication(IHost host, ThemeService themeService, ILogger<CairoApplication> logger, IOptionsMonitor<CommandLineOptions> options)
         {
             Host = host;
-            _themeService = themeServiceFactory(this);
+            _themeService = themeService;
             _logger = logger;
             _options = options;
 

--- a/Cairo Desktop/Cairo Desktop/Program.cs
+++ b/Cairo Desktop/Cairo Desktop/Program.cs
@@ -51,7 +51,8 @@ namespace CairoDesktop
                     services.AddSingleton<AppGrabberService>();
                     services.AddSingleton<ISettingsUIService, SettingsUIService>();
                     services.AddHostedService<ShellHotKeyService>();
-                    services.AddSingleton<ThemeService>();
+
+                    AddThemeService(services);
 
                     services.AddSingleton<DesktopManager>();
                     services.AddSingleton<WindowManager>();
@@ -90,6 +91,19 @@ namespace CairoDesktop
             
             var app = _host.Services.GetRequiredService<ICairoApplication>();
             return app.Run();
+        }
+
+        private static void AddThemeService(IServiceCollection services)
+        {
+            ThemeService themeService = default;
+
+            ThemeService GetThemeService(ICairoApplication cairoApplication)
+            {
+                return themeService ?? (themeService = new ThemeService(cairoApplication));
+            }
+
+            services.AddSingleton(provider => GetThemeService(provider.GetService<ICairoApplication>()));
+            services.AddSingleton<Func<ICairoApplication, ThemeService>>(provider => GetThemeService);
         }
         
         private static bool GetMutex()

--- a/Cairo Desktop/Cairo Desktop/Program.cs
+++ b/Cairo Desktop/Cairo Desktop/Program.cs
@@ -47,12 +47,13 @@ namespace CairoDesktop
 
                     services.AddSingleton(s => Settings.Instance);
                     services.AddSingleton<ICairoApplication, CairoApplication>();
+                    services.AddSingleton<Func<ICairoApplication>>(provider => provider.GetService<ICairoApplication>);
 
                     services.AddSingleton<AppGrabberService>();
                     services.AddSingleton<ISettingsUIService, SettingsUIService>();
                     services.AddHostedService<ShellHotKeyService>();
 
-                    AddThemeService(services);
+                    services.AddSingleton<ThemeService>();
 
                     services.AddSingleton<DesktopManager>();
                     services.AddSingleton<WindowManager>();
@@ -91,19 +92,6 @@ namespace CairoDesktop
             
             var app = _host.Services.GetRequiredService<ICairoApplication>();
             return app.Run();
-        }
-
-        private static void AddThemeService(IServiceCollection services)
-        {
-            ThemeService themeService = default;
-
-            ThemeService GetThemeService(ICairoApplication cairoApplication)
-            {
-                return themeService ?? (themeService = new ThemeService(cairoApplication));
-            }
-
-            services.AddSingleton(provider => GetThemeService(provider.GetService<ICairoApplication>()));
-            services.AddSingleton<Func<ICairoApplication, ThemeService>>(provider => GetThemeService);
         }
         
         private static bool GetMutex()

--- a/Cairo Desktop/Cairo Desktop/Services/ThemeService.cs
+++ b/Cairo Desktop/Cairo Desktop/Services/ThemeService.cs
@@ -24,7 +24,7 @@ namespace CairoDesktop.Services
             CairoApplication.CairoApplicationDataFolder
         };
 
-        protected readonly ICairoApplication _cairoApplication;
+        private readonly ICairoApplication _cairoApplication;
 
         public ThemeService(ICairoApplication cairoApplication)
         {


### PR DESCRIPTION
The dependency is now passed via a method parameter when calling SetThemeFromSettings from CairoApplication.
Otherwise the dependency to ThemeService is resolved lazily using a factory method.