### PR TITLE
Windows 7+ style task grouping

### DIFF
--- a/Cairo Desktop/Cairo Desktop/Cairo Desktop.csproj
+++ b/Cairo Desktop/Cairo Desktop/Cairo Desktop.csproj
@@ -67,7 +67,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedShell" Version="0.0.134" />
+    <PackageReference Include="ManagedShell" Version="0.0.136" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />

--- a/Cairo Desktop/Cairo Desktop/SettingsUI.xaml
+++ b/Cairo Desktop/Cairo Desktop/SettingsUI.xaml
@@ -768,6 +768,11 @@
                                          Click="radTaskbarGrouping1_Click">
                                 <Label Content="{Binding Path=(l10n:DisplayString.sSettings_Taskbar_GroupByApplication)}" />
                             </RadioButton>
+                            <RadioButton GroupName="rdoTaskbarGrouping"
+                                         Name="radTaskbarGrouping2"
+                                         Click="radTaskbarGrouping2_Click">
+                                <Label Content="{Binding Path=(l10n:DisplayString.sSettings_Taskbar_GroupByApplicationCombined)}" />
+                            </RadioButton>
                         </StackPanel>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal"

--- a/Cairo Desktop/Cairo Desktop/SettingsUI.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/SettingsUI.xaml.cs
@@ -190,10 +190,17 @@ namespace CairoDesktop
                 case 0:
                     radTaskbarGrouping0.IsChecked = true;
                     radTaskbarGrouping1.IsChecked = false;
+                    radTaskbarGrouping2.IsChecked = false;
                     break;
                 case 1:
                     radTaskbarGrouping0.IsChecked = false;
                     radTaskbarGrouping1.IsChecked = true;
+                    radTaskbarGrouping2.IsChecked = false;
+                    break;
+                case 2:
+                    radTaskbarGrouping0.IsChecked = false;
+                    radTaskbarGrouping1.IsChecked = false;
+                    radTaskbarGrouping2.IsChecked = true;
                     break;
                 default:
                     break;
@@ -677,6 +684,11 @@ namespace CairoDesktop
         private void radTaskbarGrouping1_Click(object sender, RoutedEventArgs e)
         {
             Settings.Instance.TaskbarGroupingStyle = 1;
+        }
+
+        private void radTaskbarGrouping2_Click(object sender, RoutedEventArgs e)
+        {
+            Settings.Instance.TaskbarGroupingStyle = 2;
         }
 
         private void radDesktopLabelPos0_Click(object sender, RoutedEventArgs e)

--- a/Cairo Desktop/Cairo Desktop/SupportingClasses/CairoAppBarWindow.cs
+++ b/Cairo Desktop/Cairo Desktop/SupportingClasses/CairoAppBarWindow.cs
@@ -1,6 +1,5 @@
 ﻿using CairoDesktop.Application.Interfaces;
 using CairoDesktop.Interfaces;
-using CairoDesktop.Services;
 using ManagedShell;
 using ManagedShell.AppBar;
 

--- a/Cairo Desktop/Cairo Desktop/SupportingClasses/TaskGroup.cs
+++ b/Cairo Desktop/Cairo Desktop/SupportingClasses/TaskGroup.cs
@@ -1,0 +1,289 @@
+﻿using CairoDesktop.Configuration;
+using ManagedShell.Common.Enums;
+using ManagedShell.Common.Helpers;
+using ManagedShell.Interop;
+using ManagedShell.UWPInterop;
+using ManagedShell.WindowsTasks;
+using System;
+using System.Collections.Specialized;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Media;
+
+namespace CairoDesktop.SupportingClasses
+{
+    public class TaskGroup : INotifyPropertyChanged, IDisposable
+    {
+        private string _title;
+
+        public string Title
+        {
+            get
+            {
+                return _title;
+            }
+            set
+            {
+                _title = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private ImageSource _icon;
+
+        public ImageSource Icon
+        {
+            get
+            {
+                return _icon;
+            }
+            set
+            {
+                _icon = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private ApplicationWindow.WindowState _state;
+
+        public ApplicationWindow.WindowState State
+        {
+            get
+            {
+                return _state;
+            }
+            set
+            {
+                _state = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private ImageSource _overlayIcon;
+
+        public ImageSource OverlayIcon
+        {
+            get
+            {
+                return _overlayIcon;
+            }
+            private set
+            {
+                _overlayIcon = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private string _overlayIconDescription;
+
+        public string OverlayIconDescription
+        {
+            get
+            {
+                return _overlayIconDescription;
+            }
+            private set
+            {
+                _overlayIconDescription = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private NativeMethods.TBPFLAG _progressState;
+
+        public NativeMethods.TBPFLAG ProgressState
+        {
+            get
+            {
+                return _progressState;
+            }
+
+            set
+            {
+                _progressState = value;
+
+                if (value == NativeMethods.TBPFLAG.TBPF_NOPROGRESS)
+                {
+                    ProgressValue = 0;
+                }
+
+                OnPropertyChanged();
+            }
+        }
+
+        private int _progressValue;
+
+        public int ProgressValue
+        {
+            get
+            {
+                return _progressValue;
+            }
+
+            set
+            {
+                _progressValue = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public ReadOnlyObservableCollection<object> Windows;
+
+        private StoreApp _storeApp;
+
+        public TaskGroup(ReadOnlyObservableCollection<object> windows)
+        {
+            State = ApplicationWindow.WindowState.Inactive;
+
+            if (windows == null)
+            {
+                return;
+            }
+
+            Windows = windows;
+            (Windows as INotifyCollectionChanged).CollectionChanged += TaskGroup_CollectionChanged;
+
+            foreach(var aWindow in Windows)
+            {
+                if (aWindow is ApplicationWindow appWindow)
+                {
+                    appWindow.PropertyChanged += ApplicationWindow_PropertyChanged;
+                }
+            }
+
+            setInitialValues();
+            setState();
+        }
+
+        private void setInitialValues()
+        {
+            if (Windows[0] is ApplicationWindow window)
+            {
+                if (window.IsUWP)
+                {
+                    _storeApp = StoreAppHelper.AppList.GetAppByAumid(window.AppUserModelID);
+                    Title = _storeApp.DisplayName;
+                    Icon = _storeApp.GetIconImageSource(IconHelper.ParseSize(Settings.Instance.TaskbarIconSize) == IconSize.Small ? IconSize.Small : IconSize.Large);
+                }
+                else
+                {
+                    Title = FileVersionInfo.GetVersionInfo(window.WinFileName).FileDescription;
+
+                    Task.Factory.StartNew(() =>
+                    {
+                        Icon = IconImageConverter.GetImageFromAssociatedIcon(window.WinFileName, IconHelper.ParseSize(Settings.Instance.TaskbarIconSize) == IconSize.Small ? IconSize.Small : IconSize.Large);
+                    }, CancellationToken.None, TaskCreationOptions.None, IconHelper.IconScheduler);
+                }
+            }
+        }
+
+        private void setState()
+        {
+            bool active = Windows.Any(win =>
+            {
+                if (win is ApplicationWindow window)
+                {
+                    return window.State == ApplicationWindow.WindowState.Active;
+                }
+
+                return false;
+            });
+
+            bool flashing = Windows.Any(win =>
+            {
+                if (win is ApplicationWindow window)
+                {
+                    return window.State == ApplicationWindow.WindowState.Flashing;
+                }
+
+                return false;
+            });
+
+            if (flashing)
+            {
+                State = ApplicationWindow.WindowState.Flashing;
+            }
+            else if (active)
+            {
+                State = ApplicationWindow.WindowState.Active;
+            }
+            else
+            {
+                State = ApplicationWindow.WindowState.Inactive;
+            }
+        }
+
+        private void ApplicationWindow_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            switch (e.PropertyName)
+            {
+                case "State":
+                    setState();
+                    break;
+                case "OverlayIcon":
+                    // TODO
+                    break;
+                case "OverlayIconDescription":
+                    // TODO
+                    break;
+                case "ProgressState":
+                    // TODO
+                    break;
+                case "ProgressValue":
+                    // TODO
+                    break;
+            }
+        }
+
+        private void TaskGroup_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (e.NewItems != null)
+            {
+                foreach (var newItem in e.NewItems)
+                {
+                    if (newItem is ApplicationWindow appWindow)
+                    {
+                        appWindow.PropertyChanged += ApplicationWindow_PropertyChanged;
+                    }
+                }
+            }
+
+            if (e.OldItems != null)
+            {
+                foreach (var oldItem in e.OldItems)
+                {
+                    if (oldItem is ApplicationWindow appWindow)
+                    {
+                        appWindow.PropertyChanged -= ApplicationWindow_PropertyChanged;
+                    }
+                }
+            }
+
+            setState();
+        }
+
+        public void Dispose()
+        {
+            foreach (var aWindow in Windows)
+            {
+                if (aWindow is ApplicationWindow appWindow)
+                {
+                    appWindow.PropertyChanged -= ApplicationWindow_PropertyChanged;
+                }
+            }
+        }
+
+        #region INotifyPropertyChanged
+        public event PropertyChangedEventHandler PropertyChanged;
+        private void OnPropertyChanged([CallerMemberName] string propertyName = "")
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+        #endregion
+    }
+}

--- a/Cairo Desktop/Cairo Desktop/SupportingClasses/TaskGroupConverter.cs
+++ b/Cairo Desktop/Cairo Desktop/SupportingClasses/TaskGroupConverter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Windows.Data;
+
+namespace CairoDesktop.SupportingClasses
+{
+    [ValueConversion(typeof(CollectionViewGroup), typeof(TaskGroup))]
+    public class TaskGroupConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (value is CollectionViewGroup group)
+            {
+                return new TaskGroup(group.Items);
+            }
+
+            return null;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Cairo Desktop/Cairo Desktop/SupportingClasses/TaskGroupConverter.cs
+++ b/Cairo Desktop/Cairo Desktop/SupportingClasses/TaskGroupConverter.cs
@@ -18,7 +18,7 @@ namespace CairoDesktop.SupportingClasses
 
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            throw new NotImplementedException();
+            return Binding.DoNothing;
         }
     }
 }

--- a/Cairo Desktop/Cairo Desktop/SupportingClasses/TaskGroupSizeConverter.cs
+++ b/Cairo Desktop/Cairo Desktop/SupportingClasses/TaskGroupSizeConverter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Windows.Data;
+
+namespace CairoDesktop.SupportingClasses
+{
+    [ValueConversion(typeof(int), typeof(bool))]
+    public class TaskGroupSizeConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (value is int count)
+            {
+                return count > 1;
+            }
+
+            return false;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Cairo Desktop/Cairo Desktop/SupportingClasses/TaskGroupSizeConverter.cs
+++ b/Cairo Desktop/Cairo Desktop/SupportingClasses/TaskGroupSizeConverter.cs
@@ -18,7 +18,7 @@ namespace CairoDesktop.SupportingClasses
 
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            throw new NotImplementedException();
+            return Binding.DoNothing;
         }
     }
 }

--- a/Cairo Desktop/Cairo Desktop/SupportingClasses/TaskThumbOrientationConverter.cs
+++ b/Cairo Desktop/Cairo Desktop/SupportingClasses/TaskThumbOrientationConverter.cs
@@ -1,0 +1,28 @@
+﻿using CairoDesktop.Configuration;
+using System;
+using System.Windows.Controls;
+using System.Windows.Data;
+
+namespace CairoDesktop.SupportingClasses
+{
+    [ValueConversion(typeof(bool), typeof(Orientation))]
+    public class TaskThumbOrientationConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (Settings.Instance.EnableTaskbarThumbnails)
+            {
+                return Orientation.Horizontal;
+            }
+            else
+            {
+                return Orientation.Vertical;
+            }
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Cairo Desktop/Cairo Desktop/SupportingClasses/TaskThumbOrientationConverter.cs
+++ b/Cairo Desktop/Cairo Desktop/SupportingClasses/TaskThumbOrientationConverter.cs
@@ -22,7 +22,7 @@ namespace CairoDesktop.SupportingClasses
 
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
-            throw new NotImplementedException();
+            return Binding.DoNothing;
         }
     }
 }

--- a/Cairo Desktop/Cairo Desktop/SupportingClasses/TaskbuttonStyleConverter.cs
+++ b/Cairo Desktop/Cairo Desktop/SupportingClasses/TaskbuttonStyleConverter.cs
@@ -17,7 +17,7 @@ namespace CairoDesktop.SupportingClasses
 
             // Default style is Inactive...
             var fxStyle = fxElement.FindResource("CairoTaskbarButtonInactiveStyle");
-            if (values[1] == null)
+            if (values[1] == DependencyProperty.UnsetValue || values[1] == null)
             {
                 // Default - couldn't get window state.
                 return fxStyle;

--- a/Cairo Desktop/Cairo Desktop/TaskButton.xaml
+++ b/Cairo Desktop/Cairo Desktop/TaskButton.xaml
@@ -69,7 +69,7 @@
                                    Text="&#x31;" />
                     </MenuItem.Icon>
                 </MenuItem>
-                <Separator />
+                <Separator Name="miSingleWindowSeparator" />
                 <MenuItem Header="{Binding Path=(l10n:DisplayString.sTaskbar_NewWindow)}" 
                           Click="miNewWindow_Click" />
                 <MenuItem Header="{Binding Path=(l10n:DisplayString.sTaskbar_Close)}" 

--- a/Cairo Desktop/Cairo Desktop/TaskButton.xaml
+++ b/Cairo Desktop/Cairo Desktop/TaskButton.xaml
@@ -91,7 +91,7 @@
                          Grid.ColumnSpan="2"
                          Minimum="0" 
                          Maximum="65534" 
-                         Value="{Binding Path=ProgressValue}" 
+                         Value="{Binding Path=ProgressValue, Mode=OneWay}" 
                          Style="{StaticResource TaskbarProgressBar}" />
             <Image Source="{Binding Path=Icon, Mode=OneWay, FallbackValue={StaticResource NullIcon}, TargetNullValue={StaticResource NullIcon}}"
                    Name="imgIcon"
@@ -99,19 +99,17 @@
                    Height="16"
                    Style="{StaticResource TaskbarButtonIcon}"
                    Grid.Column="0" />
-            <StackPanel Grid.Column="0" 
-                        HorizontalAlignment="Right"
-                        VerticalAlignment="Bottom"
-                        Margin="0,0,-2,-2"
+            <StackPanel Grid.Column="0"
+                        Style="{StaticResource TaskbarButtonOverlayPanel}"
                         Name="overlayIcon"
                         Visibility="Collapsed">
                 <Image Source="{Binding Path=OverlayIcon, Mode=OneWay}"
                        Width="16"
                        Height="16"
-                       ToolTip="{Binding Path=OverlayIconDescription}"/>
+                       ToolTip="{Binding Path=OverlayIconDescription, Mode=OneWay}"/>
             </StackPanel>
             <TextBlock Name="WinTitle" 
-                       Text="{Binding Path=Title}"
+                       Text="{Binding Path=Title, Mode=OneWay}"
                        Style="{StaticResource TaskbarButtonTitle}"
                        Grid.Column="1" />
         </Grid>

--- a/Cairo Desktop/Cairo Desktop/TaskButton.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/TaskButton.xaml.cs
@@ -9,6 +9,8 @@ using System.Windows.Threading;
 using ManagedShell.Common.Enums;
 using ManagedShell.Common.Helpers;
 using ManagedShell.WindowsTasks;
+using System.Collections.ObjectModel;
+using CairoDesktop.SupportingClasses;
 
 namespace CairoDesktop
 {
@@ -29,10 +31,13 @@ namespace CairoDesktop
             set { SetValue(ParentTaskbarProperty, value); }
         }
 
-        public ApplicationWindow Window;
+        public ReadOnlyObservableCollection<object> WindowGroup { get; set; }
+
         private DispatcherTimer dragTimer;
         private DispatcherTimer thumbTimer;
         public TaskThumbWindow ThumbWindow;
+
+        private bool _isGroup => WindowGroup != null && WindowGroup.Count > 1;
 
         public TaskButton()
         {
@@ -42,52 +47,44 @@ namespace CairoDesktop
             Settings.Instance.PropertyChanged += Instance_PropertyChanged;
         }
 
+        private ApplicationWindow getWindow()
+        {
+            if (WindowGroup == null || WindowGroup.Count < 1)
+            {
+                return null;
+            }
+
+            return WindowGroup[0] as ApplicationWindow;
+        }
+
         public void SelectWindow()
         {
-            if (Window != null)
+            if (_isGroup)
+            {
+                openThumb();
+                return;
+            }
+
+            if (getWindow() is ApplicationWindow window)
             {
                 if (Keyboard.IsKeyDown(Key.LeftShift) ||
                     Keyboard.IsKeyDown(Key.RightShift))
                 {
-                    ShellHelper.StartProcess(Window.WinFileName);
+                    ShellHelper.StartProcess(window.IsUWP ? "appx:" + window.AppUserModelID : window.WinFileName);
                     return;
                 }
 
-                if (Window.State == ApplicationWindow.WindowState.Active)
+                if (window.State == ApplicationWindow.WindowState.Active)
                 {
-                    Window.Minimize();
+                    window.Minimize();
                 }
                 else
                 {
-                    Window.BringToFront();
+                    window.BringToFront();
                 }
             }
 
             closeThumb(true);
-        }
-
-        public void ConfigureContextMenu()
-        {
-            if (Window != null)
-            {
-                Visibility vis = Visibility.Collapsed;
-                NativeMethods.WindowShowStyle wss = Window.ShowStyle;
-                int ws = Window.WindowStyles;
-
-                // show pin option if this app is not yet in quick launch
-                if (ParentTaskbar._appGrabber.QuickLaunchManager.GetQuickLaunchApplicationInfo(Window) == null)
-                    vis = Visibility.Visible;
-
-                miPin.Visibility = vis;
-                miPinSeparator.Visibility = vis;
-
-                // disable window operations depending on current window state. originally tried implementing via bindings but found there is no notification we get regarding maximized state
-                miMaximize.IsEnabled = (wss != NativeMethods.WindowShowStyle.ShowMaximized && (ws & (int)NativeMethods.WindowStyles.WS_MAXIMIZEBOX) != 0);
-                miMinimize.IsEnabled = (wss != NativeMethods.WindowShowStyle.ShowMinimized && (ws & (int)NativeMethods.WindowStyles.WS_MINIMIZEBOX) != 0);
-                miRestore.IsEnabled = (wss != NativeMethods.WindowShowStyle.ShowNormal);
-                miMove.IsEnabled = wss == NativeMethods.WindowShowStyle.ShowNormal;
-                miSize.IsEnabled = (wss == NativeMethods.WindowShowStyle.ShowNormal && (ws & (int)NativeMethods.WindowStyles.WS_MAXIMIZEBOX) != 0);
-            }
         }
 
         public void SetParentAutoHide(bool enabled)
@@ -95,12 +92,30 @@ namespace CairoDesktop
             if (!ListMode && ParentTaskbar != null) ParentTaskbar.CanAutoHide = enabled;
         }
 
+        private void closeWindows()
+        {
+            if (WindowGroup != null)
+            {
+                foreach (ApplicationWindow window in WindowGroup)
+                {
+                    window.Close();
+                }
+            }
+        }
+
         #region Events
         private void UserControl_Loaded(object sender, RoutedEventArgs e)
         {
-            Window = DataContext as ApplicationWindow;
-
-            Window.PropertyChanged += Window_PropertyChanged;
+            if (DataContext is TaskGroup group)
+            {
+                WindowGroup = group.Windows;
+                group.PropertyChanged += Data_PropertyChanged;
+            }
+            else if (DataContext is ApplicationWindow window)
+            {
+                WindowGroup = new ReadOnlyObservableCollection<object>(new ObservableCollection<object>() { window });
+                window.PropertyChanged += Data_PropertyChanged;
+            }
 
             if (!ListMode)
             {
@@ -129,7 +144,15 @@ namespace CairoDesktop
 
         private void TaskButton_OnUnloaded(object sender, RoutedEventArgs e)
         {
-            Window.PropertyChanged -= Window_PropertyChanged;
+            if (DataContext is TaskGroup group)
+            {
+                group.PropertyChanged -= Data_PropertyChanged;
+            }
+            else if (DataContext is ApplicationWindow window)
+            {
+                window.PropertyChanged -= Data_PropertyChanged;
+            }
+
             Settings.Instance.PropertyChanged -= Instance_PropertyChanged;
         }
 
@@ -154,13 +177,14 @@ namespace CairoDesktop
             }
         }
 
-        private void Window_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void Data_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {
                 // handle progress changes
                 case "ProgressState":
-                    pbProgress.IsIndeterminate = Window.ProgressState == NativeMethods.TBPFLAG.TBPF_INDETERMINATE;
+                    // TODO: this is wrong for groups
+                    pbProgress.IsIndeterminate = getWindow().ProgressState == NativeMethods.TBPFLAG.TBPF_INDETERMINATE;
                     break;
             }
         }
@@ -212,116 +236,25 @@ namespace CairoDesktop
             SelectWindow();
         }
 
-        private void miRestore_Click(object sender, RoutedEventArgs e)
-        {
-            if (Window != null)
-            {
-                Window.Restore();
-            }
-        }
-
-        private void miMove_Click(object sender, RoutedEventArgs e)
-        {
-            if (Window != null)
-            {
-                Window.Move();
-            }
-        }
-
-        private void miSize_Click(object sender, RoutedEventArgs e)
-        {
-            if (Window != null)
-            {
-                Window.Size();
-            }
-        }
-
-        private void miMinimize_Click(object sender, RoutedEventArgs e)
-        {
-            if (Window != null)
-            {
-                Window.Minimize();
-            }
-        }
-
-        private void miMaximize_Click(object sender, RoutedEventArgs e)
-        {
-            if (Window != null)
-            {
-                Window.Maximize();
-            }
-        }
-
-        private void miNewWindow_Click(object sender, RoutedEventArgs e)
-        {
-            if (Window != null)
-            {
-                ShellHelper.StartProcess(Window.WinFileName);
-            }
-        }
-
-        private void miClose_Click(object sender, RoutedEventArgs e)
-        {
-            if (Window != null)
-            {
-                Window.Close();
-            }
-        }
-
-        /// <summary>
-        /// Handler that adjusts the visibility and usability of menu items depending on window state and app's inclusion in Quick Launch.
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void ContextMenu_Opening(object sender, ContextMenuEventArgs e)
-        {
-            ConfigureContextMenu();
-        }
-
-        private void ContextMenu_Closed(object sender, RoutedEventArgs e)
-        {
-            if (!IsMouseOver) closeThumb(true);
-            SetParentAutoHide(true);
-        }
-
-        private void miPin_Click(object sender, RoutedEventArgs e)
-        {
-            if (Window != null)
-            {
-                ParentTaskbar._appGrabber.QuickLaunchManager.PinToQuickLaunch(Window.IsUWP, Window.IsUWP ? Window.AppUserModelID : Window.WinFileName);
-            }
-        }
-
-        private void miTaskMan_Click(object sender, RoutedEventArgs e)
-        {
-            ShellHelper.StartTaskManager();
-        }
-
         private void btn_MouseUp(object sender, MouseButtonEventArgs e)
         {
-            if (e.ChangedButton != MouseButton.Middle || Window == null)
+            if (e.ChangedButton == MouseButton.Middle)
             {
-                return;
-            }
-
-            switch (Settings.Instance.TaskbarMiddleClick)
-            {
-                case 0 when Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift):
-                    Window.Close();
-                    break;
-                case 1 when !Keyboard.IsKeyDown(Key.LeftShift) && !Keyboard.IsKeyDown(Key.RightShift):
-                    Window.Close();
-                    break;
-                default:
-                    if (Window.IsUWP)
-                    {
-                        ShellHelper.StartProcess("appx:" + Window.AppUserModelID);
-                    }
-                    else
-                    {
-                        ShellHelper.StartProcess(Window.WinFileName);
-                    }
-                    break;
+                switch (Settings.Instance.TaskbarMiddleClick)
+                {
+                    case 0 when Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift):
+                        closeWindows();
+                        break;
+                    case 1 when !Keyboard.IsKeyDown(Key.LeftShift) && !Keyboard.IsKeyDown(Key.RightShift):
+                        closeWindows();
+                        break;
+                    default:
+                        if (getWindow() is ApplicationWindow window)
+                        {
+                            ShellHelper.StartProcess(window.IsUWP ? "appx:" + window.AppUserModelID : window.WinFileName);
+                        }
+                        break;
+                }
             }
         }
 
@@ -341,14 +274,127 @@ namespace CairoDesktop
         }
         #endregion
 
+        #region Context menu
+
+        private void ContextMenu_Opening(object sender, RoutedEventArgs e)
+        {
+            ApplicationWindow window = getWindow();
+
+            if (window == null)
+            {
+                return;
+            }
+
+            Visibility pinVisibility = Visibility.Collapsed;
+            Visibility singleWindowVisibility = Visibility.Collapsed;
+            NativeMethods.WindowShowStyle wss = window.ShowStyle;
+            int ws = window.WindowStyles;
+
+            // show pin option if this app is not yet in quick launch
+            if (ParentTaskbar._appGrabber.QuickLaunchManager.GetQuickLaunchApplicationInfo(window) == null)
+            {
+                pinVisibility = Visibility.Visible;
+            }
+
+            miPin.Visibility = pinVisibility;
+            miPinSeparator.Visibility = pinVisibility;
+
+            if (!_isGroup)
+            {
+                // disable window operations depending on current window state. originally tried implementing via bindings but found there is no notification we get regarding maximized state
+                miMaximize.IsEnabled = wss != NativeMethods.WindowShowStyle.ShowMaximized && (ws & (int)NativeMethods.WindowStyles.WS_MAXIMIZEBOX) != 0;
+                miMinimize.IsEnabled = wss != NativeMethods.WindowShowStyle.ShowMinimized && (ws & (int)NativeMethods.WindowStyles.WS_MINIMIZEBOX) != 0;
+                miRestore.IsEnabled = wss != NativeMethods.WindowShowStyle.ShowNormal;
+                miMove.IsEnabled = wss == NativeMethods.WindowShowStyle.ShowNormal;
+                miSize.IsEnabled = wss == NativeMethods.WindowShowStyle.ShowNormal && (ws & (int)NativeMethods.WindowStyles.WS_MAXIMIZEBOX) != 0;
+            }
+            else
+            {
+                // hide single window controls if group button
+                miMaximize.Visibility = singleWindowVisibility;
+                miMinimize.Visibility = singleWindowVisibility;
+                miRestore.Visibility = singleWindowVisibility;
+                miMove.Visibility = singleWindowVisibility;
+                miSize.Visibility = singleWindowVisibility;
+                miSingleWindowSeparator.Visibility = singleWindowVisibility;
+            }
+        }
+
+        private void ContextMenu_Closed(object sender, RoutedEventArgs e)
+        {
+            if (!IsMouseOver) closeThumb(true);
+            SetParentAutoHide(true);
+        }
+
+        private void miRestore_Click(object sender, RoutedEventArgs e)
+        {
+            getWindow()?.Restore();
+        }
+
+        private void miMove_Click(object sender, RoutedEventArgs e)
+        {
+            getWindow()?.Move();
+        }
+
+        private void miSize_Click(object sender, RoutedEventArgs e)
+        {
+            getWindow()?.Size();
+        }
+
+        private void miMinimize_Click(object sender, RoutedEventArgs e)
+        {
+            getWindow()?.Minimize();
+        }
+
+        private void miMaximize_Click(object sender, RoutedEventArgs e)
+        {
+            getWindow()?.Maximize();
+        }
+
+        private void miNewWindow_Click(object sender, RoutedEventArgs e)
+        {
+            ApplicationWindow toOpen = getWindow();
+
+            if (toOpen != null)
+            {
+                ShellHelper.StartProcess(toOpen.IsUWP ? "appx:" + toOpen.AppUserModelID : toOpen.WinFileName);
+            }
+        }
+
+        private void miClose_Click(object sender, RoutedEventArgs e)
+        {
+            closeWindows();
+        }
+
+        private void miPin_Click(object sender, RoutedEventArgs e)
+        {
+            ApplicationWindow toPin = getWindow();
+
+            if (toPin != null)
+            {
+                ParentTaskbar._appGrabber.QuickLaunchManager.PinToQuickLaunch(toPin.IsUWP, toPin.IsUWP ? toPin.AppUserModelID : toPin.WinFileName);
+            }
+        }
+
+        private void miTaskMan_Click(object sender, RoutedEventArgs e)
+        {
+            ShellHelper.StartTaskManager();
+        }
+
+        #endregion
+
         #region Drag support
         private bool inDrag = false;
 
         private void dragTimer_Tick(object sender, EventArgs e)
         {
-            if (inDrag && Window != null)
+            if (inDrag && _isGroup)
             {
-                Window.BringToFront();
+                openThumb();
+            }
+            else if (inDrag && getWindow() is ApplicationWindow window)
+            {
+                window.BringToFront();
             }
 
             dragTimer.Stop();
@@ -384,7 +430,7 @@ namespace CairoDesktop
 
         private void openThumb()
         {
-            if (!ListMode && ThumbWindow == null && Settings.Instance.EnableTaskbarThumbnails)
+            if (!ListMode && ThumbWindow == null && (Settings.Instance.EnableTaskbarThumbnails || _isGroup))
             {
                 ThumbWindow = new TaskThumbWindow(this);
                 ThumbWindow.Owner = ParentTaskbar;
@@ -395,7 +441,7 @@ namespace CairoDesktop
         private void closeThumb(bool force = false)
         {
             thumbTimer.Stop();
-            if (!ListMode && ThumbWindow != null && !btn.ContextMenu.IsOpen && (!ThumbWindow.IsMouseOver || force))
+            if (!ListMode && ThumbWindow != null && (!ThumbWindow.IsMouseOver || force))
             {
                 ThumbWindow.Close();
                 ThumbWindow = null;

--- a/Cairo Desktop/Cairo Desktop/TaskButton.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/TaskButton.xaml.cs
@@ -183,8 +183,14 @@ namespace CairoDesktop
             {
                 // handle progress changes
                 case "ProgressState":
-                    // TODO: this is wrong for groups
-                    pbProgress.IsIndeterminate = getWindow().ProgressState == NativeMethods.TBPFLAG.TBPF_INDETERMINATE;
+                    if (sender is TaskGroup group)
+                    {
+                        pbProgress.IsIndeterminate = group.ProgressState == NativeMethods.TBPFLAG.TBPF_INDETERMINATE;
+                    }
+                    else if (sender is ApplicationWindow window)
+                    {
+                        pbProgress.IsIndeterminate = window.ProgressState == NativeMethods.TBPFLAG.TBPF_INDETERMINATE;
+                    }
                     break;
             }
         }
@@ -388,11 +394,7 @@ namespace CairoDesktop
 
         private void dragTimer_Tick(object sender, EventArgs e)
         {
-            if (inDrag && _isGroup)
-            {
-                openThumb();
-            }
-            else if (inDrag && getWindow() is ApplicationWindow window)
+            if (inDrag && getWindow() is ApplicationWindow window)
             {
                 window.BringToFront();
             }
@@ -450,7 +452,7 @@ namespace CairoDesktop
 
         public Point GetThumbnailAnchor()
         {
-            Window ancestor = System.Windows.Window.GetWindow(this);
+            Window ancestor = Window.GetWindow(this);
             if (ancestor != null)
             {
                 var generalTransform = TransformToAncestor(ancestor);

--- a/Cairo Desktop/Cairo Desktop/TaskThumbWindow.xaml
+++ b/Cairo Desktop/Cairo Desktop/TaskThumbWindow.xaml
@@ -2,6 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:CairoDesktop"
+        xmlns:support="clr-namespace:CairoDesktop.SupportingClasses" 
         Title="TaskThumbWindow"
         SizeToContent="WidthAndHeight"
         Focusable="False"
@@ -15,10 +16,14 @@
         Closing="Window_Closing"
         MouseLeave="Window_MouseLeave"
         Topmost="True"
-        ToolTip="{Binding Path=Title}"
         ToolTipService.Placement="Top"
         UseLayoutRounding="True"
-        MouseEnter="Window_MouseEnter">
+        x:Name="ThumbWindow">
+    <Window.Resources>
+        <ResourceDictionary>
+            <support:TaskThumbOrientationConverter x:Key="orientationConverter" />
+        </ResourceDictionary>
+    </Window.Resources>
     <Border Name="bdrThumb"
             Style="{StaticResource TaskThumbWindowBorderStyle}">
         <Border.RenderTransform>
@@ -43,37 +48,18 @@
         </Border.Triggers>
         <Border Name="bdrThumbInner"
                 Style="{StaticResource TaskThumbWindowInnerBorderStyle}">
-            <Border Style="{StaticResource TaskThumbWindowInnerStyle}"
-                    MouseEnter="bdrThumbInner_OnMouseEnter"
-                    MouseLeave="bdrThumbInner_OnMouseLeave"
-                    MouseUp="bdrThumbInner_MouseUp"
-                    MouseRightButtonUp="bdrThumbInner_MouseRightButtonUp">
-                <StackPanel>
-                    <StackPanel Name="pnlTitle"
-                                Orientation="Horizontal"
-                                Margin="0,0,0,5">
-                        <Image Source="{Binding Path=Icon, Mode=OneWay, FallbackValue={StaticResource NullIcon}, TargetNullValue={StaticResource NullIcon}}"
-                               Width="16"
-                               Height="16" />
-                        <TextBlock Style="{StaticResource TaskThumbTitleStyle}"
-                                   Text="{Binding Path=Title}"
-                                   Width="138" />
-                        <Button	Name="closeButton" 
-                                Style="{StaticResource TaskThumbCloseButton}"
-                                Visibility="Hidden"
-                                Click="Button_Click">
-                            <Path Data="M 18,11 27,20 M 18,20 27,11"	
-                                  Stroke="{Binding Path=Foreground,	RelativeSource={RelativeSource AncestorType={x:Type Button}}}"		
-                                  StrokeThickness="1" Stretch="Fill" />
-                        </Button>
-                    </StackPanel>
-                    <local:DwmThumbnail x:Name="dwmThumbnail"
-                                        Width="180"
-                                        Height="120" />
-
-                </StackPanel>
-
-            </Border>
+            <ItemsControl ItemsSource="{Binding WindowGroup}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <local:TaskThumbnail ThumbWindow="{Binding ElementName=ThumbWindow}" />
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Orientation="{Binding Converter={StaticResource orientationConverter}}"></StackPanel>
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+            </ItemsControl>
         </Border>
     </Border>
 </Window>

--- a/Cairo Desktop/Cairo Desktop/TaskThumbWindow.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/TaskThumbWindow.xaml.cs
@@ -13,28 +13,24 @@ namespace CairoDesktop
     /// </summary>
     public partial class TaskThumbWindow : Window
     {
-        private TaskButton taskButton;
+        internal TaskButton TaskButton;
+        internal bool IsAnimating = true;
+        internal bool IsDwmEnabled;
+        internal bool IsContextMenuOpen;
+
         private bool isClosing;
-        private bool isAnimating;
-        private bool isDwmEnabled;
         private IntPtr handle;
 
         public TaskThumbWindow(TaskButton parent)
         {
             InitializeComponent();
 
-            taskButton = parent;
-            DataContext = parent.Window;
+            TaskButton = parent;
+            DataContext = TaskButton;
 
-            taskButton.SetParentAutoHide(false);
+            TaskButton.SetParentAutoHide(false);
 
-            // check if DWM is enabled, if not, hide the thumbnail placeholder
-            isDwmEnabled = NativeMethods.DwmIsCompositionEnabled();
-            if (!isDwmEnabled)
-            {
-                dwmThumbnail.Visibility = Visibility.Collapsed;
-                pnlTitle.Margin = new Thickness(0);
-            }
+            IsDwmEnabled = NativeMethods.DwmIsCompositionEnabled();
         }
 
         private void Window_SourceInitialized(object sender, EventArgs e)
@@ -45,12 +41,12 @@ namespace CairoDesktop
             WindowHelper.HideWindowFromTasks(handle);
 
             // get anchor point
-            Point taskButtonPoint = taskButton.GetThumbnailAnchor();
+            Point taskButtonPoint = TaskButton.GetThumbnailAnchor();
 
             if (Configuration.Settings.Instance.TaskbarPosition == 1)
             {
                 // taskbar on top
-                Top = taskButtonPoint.Y + taskButton.ActualHeight;
+                Top = taskButtonPoint.Y + TaskButton.ActualHeight;
 
                 bdrThumb.Style = FindResource("TaskThumbWindowBorderTopStyle") as Style;
                 bdrThumbInner.Style = FindResource("TaskThumbWindowInnerBorderTopStyle") as Style;
@@ -64,98 +60,25 @@ namespace CairoDesktop
                 Top = taskButtonPoint.Y - ActualHeight;
             }
 
-            Left = taskButtonPoint.X - ((ActualWidth - taskButton.ActualWidth) / 2);
-
-            if (isDwmEnabled)
-            {
-                // set up thumbnail
-                dwmThumbnail.DpiScale = taskButton.ParentTaskbar.DpiScale;
-                dwmThumbnail.ThumbnailOpacity = 0;
-                dwmThumbnail.SourceWindowHandle = taskButton.Window.Handle;
-
-                // set up animation
-                isAnimating = true;
-                System.Windows.Media.CompositionTarget.Rendering += CompositionTarget_Rendering;
-            }
-        }
-
-        private void CompositionTarget_Rendering(object sender, EventArgs e)
-        {
-            // runs once per frame for the duration of the animation
-            if (isAnimating)
-            {
-                dwmThumbnail.ThumbnailOpacity = Convert.ToByte(bdrThumb.Opacity * 255);
-                dwmThumbnail.Refresh();
-            }
-            else
-            {
-                // refresh one last time to get the final frame's updates
-                dwmThumbnail.ThumbnailOpacity = 255;
-                dwmThumbnail.Refresh();
-                System.Windows.Media.CompositionTarget.Rendering -= CompositionTarget_Rendering;
-            }
+            Left = taskButtonPoint.X - ((ActualWidth - TaskButton.ActualWidth) / 2);
         }
 
         private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
         {
             isClosing = true;
-            if (isDwmEnabled) dwmThumbnail.SourceWindowHandle = IntPtr.Zero;
-            taskButton.ThumbWindow = null;
-            taskButton.SetParentAutoHide(true);
+            TaskButton.ThumbWindow = null;
+            TaskButton.SetParentAutoHide(true);
         }
 
         private void Window_MouseLeave(object sender, MouseEventArgs e)
         {
-            if (!isClosing && !taskButton.btn.ContextMenu.IsOpen && !taskButton.IsMouseOver)
+            if (!isClosing && !IsContextMenuOpen && !TaskButton.IsMouseOver)
                 Close();
-        }
-
-        private void bdrThumbInner_MouseUp(object sender, MouseButtonEventArgs e)
-        {
-            if (e.ChangedButton == MouseButton.Left)
-            {
-                taskButton.SelectWindow();
-                Close();
-            }
-        }
-
-        private void bdrThumbInner_MouseRightButtonUp(object sender, MouseButtonEventArgs e)
-        {
-            taskButton.ConfigureContextMenu();
-            taskButton.btn.ContextMenu.IsOpen = true;
         }
 
         private void Storyboard_Completed(object sender, EventArgs e)
         {
-            isAnimating = false;
-        }
-
-        private void bdrThumbInner_OnMouseEnter(object sender, MouseEventArgs e)
-        {
-            if (isDwmEnabled)
-            {
-                WindowHelper.PeekWindow(true, taskButton.Window.Handle, taskButton.ParentTaskbar.Handle);
-            }
-        }
-
-        private void bdrThumbInner_OnMouseLeave(object sender, MouseEventArgs e)
-        {
-            if (isDwmEnabled)
-            {
-                WindowHelper.PeekWindow(false, taskButton.Window.Handle, taskButton.ParentTaskbar.Handle);
-            }
-        }
-
-        private void Button_Click(object sender, RoutedEventArgs e)
-        {
-            taskButton.Window.Close();
-            Close();
-        }
-
-        private void Window_MouseEnter(object sender, MouseEventArgs e)
-        {
-            if (closeButton.Visibility != Visibility.Visible)
-                closeButton.Visibility = Visibility.Visible;
+            IsAnimating = false;
         }
     }
 }

--- a/Cairo Desktop/Cairo Desktop/TaskThumbnail.xaml
+++ b/Cairo Desktop/Cairo Desktop/TaskThumbnail.xaml
@@ -1,0 +1,80 @@
+﻿<UserControl x:Class="CairoDesktop.TaskThumbnail"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:CairoDesktop"
+             xmlns:l10n="clr-namespace:CairoDesktop.Localization;assembly=CairoDesktop.Localization"
+             Loaded="UserControl_Loaded"
+             Unloaded="UserControl_Unloaded"
+             ContextMenuOpening="UserControl_ContextMenuOpening">
+    <UserControl.ContextMenu>
+        <ContextMenu Closed="ContextMenu_Closed">
+            <MenuItem Header="{Binding Path=(l10n:DisplayString.sTaskbar_Restore)}" 
+                          Click="miRestore_Click" 
+                          Name="miRestore">
+                <MenuItem.Icon>
+                    <TextBlock FontFamily="Marlett" 
+                                   Text="&#x32;" />
+                </MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="{Binding Path=(l10n:DisplayString.sTaskbar_Move)}" 
+                          Click="miMove_Click"  
+                          Name="miMove" />
+            <MenuItem Header="{Binding Path=(l10n:DisplayString.sTaskbar_Size)}" 
+                          Click="miSize_Click"  
+                          Name="miSize" />
+            <MenuItem Header="{Binding Path=(l10n:DisplayString.sTaskbar_Minimize)}" 
+                          Click="miMinimize_Click" 
+                          Name="miMinimize">
+                <MenuItem.Icon>
+                    <TextBlock FontFamily="Marlett" 
+                                   Text="&#x30;" />
+                </MenuItem.Icon>
+            </MenuItem>
+            <MenuItem Header="{Binding Path=(l10n:DisplayString.sTaskbar_Maximize)}" 
+                          Click="miMaximize_Click" 
+                          Name="miMaximize">
+                <MenuItem.Icon>
+                    <TextBlock FontFamily="Marlett" 
+                                   Text="&#x31;" />
+                </MenuItem.Icon>
+            </MenuItem>
+            <Separator />
+            <MenuItem Header="{Binding Path=(l10n:DisplayString.sTaskbar_Close)}" 
+                          Click="miClose_Click">
+                <MenuItem.Icon>
+                    <TextBlock FontFamily="Marlett" 
+                                   Text="&#x72;" />
+                </MenuItem.Icon>
+            </MenuItem>
+        </ContextMenu>
+    </UserControl.ContextMenu>
+    <Border Style="{StaticResource TaskThumbWindowInnerStyle}"
+            MouseEnter="bdrThumbInner_OnMouseEnter"
+            MouseLeave="bdrThumbInner_OnMouseLeave"
+            MouseUp="bdrThumbInner_MouseUp">
+        <StackPanel>
+            <StackPanel Name="pnlTitle"
+                        Orientation="Horizontal"
+                        Margin="0,0,0,5">
+                <Image Source="{Binding Path=Icon, Mode=OneWay, FallbackValue={StaticResource NullIcon}, TargetNullValue={StaticResource NullIcon}}"
+                        Width="16"
+                        Height="16" />
+                <TextBlock Style="{StaticResource TaskThumbTitleStyle}"
+                           Text="{Binding Path=Title}"
+                           Width="138" />
+                <Button	Name="closeButton" 
+                        Style="{StaticResource TaskThumbCloseButton}"
+                        Visibility="Hidden"
+                        Click="Button_Click">
+                    <Path Data="M 18,11 27,20 M 18,20 27,11"	
+                          Stroke="{Binding Path=Foreground,	RelativeSource={RelativeSource AncestorType={x:Type Button}}}"		
+                          StrokeThickness="1"
+                          Stretch="Fill" />
+                </Button>
+            </StackPanel>
+            <local:DwmThumbnail x:Name="dwmThumbnail"
+                                Width="180"
+                                Height="120" />
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/Cairo Desktop/Cairo Desktop/TaskThumbnail.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/TaskThumbnail.xaml.cs
@@ -1,0 +1,228 @@
+﻿using CairoDesktop.Configuration;
+using CairoDesktop.SupportingClasses;
+using ManagedShell.Common.Helpers;
+using ManagedShell.Interop;
+using ManagedShell.WindowsTasks;
+using System;
+using System.Collections.ObjectModel;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace CairoDesktop
+{
+    /// <summary>
+    /// Interaction logic for TaskThumbnail.xaml
+    /// </summary>
+    public partial class TaskThumbnail : UserControl
+    {
+        private ApplicationWindow _window;
+        private bool _isLoaded;
+        private IntPtr _taskbarHwnd;
+
+        public static DependencyProperty ThumbWindowProperty = DependencyProperty.Register("ThumbWindow", typeof(TaskThumbWindow), typeof(TaskThumbnail));
+
+        public TaskThumbWindow ThumbWindow
+        {
+            get { return (TaskThumbWindow)GetValue(ThumbWindowProperty); }
+            set { SetValue(ThumbWindowProperty, value); }
+        }
+
+        public TaskThumbnail()
+        {
+            InitializeComponent();
+        }
+
+        private void UserControl_Loaded(object sender, RoutedEventArgs e)
+        {
+            if (_isLoaded)
+            {
+                return;
+            }
+
+            _window = DataContext as ApplicationWindow;
+
+            // if DWM or thumbnails disabled, hide the thumbnail placeholder
+            if (!ThumbWindow.IsDwmEnabled || !Settings.Instance.EnableTaskbarThumbnails)
+            {
+                dwmThumbnail.Visibility = Visibility.Collapsed;
+                pnlTitle.Margin = new Thickness(0);
+            }
+            else
+            {
+                _taskbarHwnd = ThumbWindow.TaskButton.ParentTaskbar.Handle;
+
+                // set up thumbnail
+                dwmThumbnail.DpiScale = ThumbWindow.TaskButton.ParentTaskbar.DpiScale;
+                dwmThumbnail.ThumbnailOpacity = 0;
+                dwmThumbnail.SourceWindowHandle = _window.Handle;
+
+                // set up animation
+                CompositionTarget.Rendering += CompositionTarget_Rendering;
+            }
+
+            _isLoaded = true;
+        }
+
+        private void UserControl_Unloaded(object sender, RoutedEventArgs e)
+        {
+            if (!_isLoaded)
+            {
+                return;
+            }
+
+            if (ThumbWindow.IsDwmEnabled)
+            {
+                dwmThumbnail.SourceWindowHandle = IntPtr.Zero;
+            }
+            _isLoaded = false;
+        }
+
+        private void CompositionTarget_Rendering(object sender, EventArgs e)
+        {
+            // runs once per frame for the duration of the animation
+            if (ThumbWindow.IsAnimating)
+            {
+                dwmThumbnail.ThumbnailOpacity = Convert.ToByte(ThumbWindow.bdrThumb.Opacity * 255);
+                dwmThumbnail.Refresh();
+            }
+            else
+            {
+                // refresh one last time to get the final frame's updates
+                dwmThumbnail.ThumbnailOpacity = 255;
+                dwmThumbnail.Refresh();
+                CompositionTarget.Rendering -= CompositionTarget_Rendering;
+            }
+        }
+
+        private void bdrThumbInner_MouseUp(object sender, MouseButtonEventArgs e)
+        {
+            if (e.ChangedButton == MouseButton.Left)
+            {
+                if (_window == null)
+                {
+                    return;
+                }
+
+                if (Keyboard.IsKeyDown(Key.LeftShift) ||
+                    Keyboard.IsKeyDown(Key.RightShift))
+                {
+                    ShellHelper.StartProcess(_window.IsUWP ? "appx:" + _window.AppUserModelID : _window.WinFileName);
+                    return;
+                }
+
+                if (_window.State == ApplicationWindow.WindowState.Active)
+                {
+                    _window.Minimize();
+                }
+                else
+                {
+                    _window.BringToFront();
+                }
+
+                ThumbWindow.Close();
+            }
+        }
+
+        #region Context menu
+        private void UserControl_ContextMenuOpening(object sender, ContextMenuEventArgs e)
+        {
+            ThumbWindow.IsContextMenuOpen = true;
+
+            if (_window == null)
+            {
+                return;
+            }
+
+            NativeMethods.WindowShowStyle wss = _window.ShowStyle;
+            int ws = _window.WindowStyles;
+
+            miMaximize.IsEnabled = wss != NativeMethods.WindowShowStyle.ShowMaximized && (ws & (int)NativeMethods.WindowStyles.WS_MAXIMIZEBOX) != 0;
+            miMinimize.IsEnabled = wss != NativeMethods.WindowShowStyle.ShowMinimized && (ws & (int)NativeMethods.WindowStyles.WS_MINIMIZEBOX) != 0;
+            miRestore.IsEnabled = wss != NativeMethods.WindowShowStyle.ShowNormal;
+            miMove.IsEnabled = wss == NativeMethods.WindowShowStyle.ShowNormal;
+            miSize.IsEnabled = wss == NativeMethods.WindowShowStyle.ShowNormal && (ws & (int)NativeMethods.WindowStyles.WS_MAXIMIZEBOX) != 0;
+        }
+
+        private void ContextMenu_Closed(object sender, RoutedEventArgs e)
+        {
+            ThumbWindow.IsContextMenuOpen = false;
+            ThumbWindow.Close();
+        }
+
+        private void miRestore_Click(object sender, RoutedEventArgs e)
+        {
+            _window?.Restore();
+        }
+
+        private void miMove_Click(object sender, RoutedEventArgs e)
+        {
+            _window?.Move();
+        }
+
+        private void miSize_Click(object sender, RoutedEventArgs e)
+        {
+            _window?.Size();
+        }
+
+        private void miMinimize_Click(object sender, RoutedEventArgs e)
+        {
+            _window?.Minimize();
+        }
+
+        private void miMaximize_Click(object sender, RoutedEventArgs e)
+        {
+            _window?.Maximize();
+        }
+
+        private void miClose_Click(object sender, RoutedEventArgs e)
+        {
+            _window?.Close();
+        }
+        #endregion
+
+        private void bdrThumbInner_OnMouseEnter(object sender, MouseEventArgs e)
+        {
+            if (closeButton.Visibility != Visibility.Visible)
+            {
+                closeButton.Visibility = Visibility.Visible;
+            }
+
+            if (ThumbWindow.IsDwmEnabled)
+            {
+                WindowHelper.PeekWindow(true, _window.Handle, _taskbarHwnd);
+            }
+        }
+
+        private void bdrThumbInner_OnMouseLeave(object sender, MouseEventArgs e)
+        {
+            if (closeButton.Visibility == Visibility.Visible)
+            {
+                closeButton.Visibility = Visibility.Hidden;
+            }
+
+            if (ThumbWindow.IsDwmEnabled)
+            {
+                WindowHelper.PeekWindow(false, _window.Handle, _taskbarHwnd);
+            }
+        }
+
+        private void Button_Click(object sender, RoutedEventArgs e)
+        {
+            bool closeThumbWindow = true;
+
+            if (ThumbWindow.TaskButton.WindowGroup.Count > 1)
+            {
+                closeThumbWindow = false;
+            }
+
+            _window.Close();
+
+            if (closeThumbWindow)
+            {
+                ThumbWindow.Close();
+            }
+        }
+    }
+}

--- a/Cairo Desktop/Cairo Desktop/TaskThumbnail.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/TaskThumbnail.xaml.cs
@@ -49,6 +49,10 @@ namespace CairoDesktop
             }
             else
             {
+                if (ThumbWindow.TaskButton.ParentTaskbar == null)
+                {
+                    return;
+                }
                 _taskbarHwnd = ThumbWindow.TaskButton.ParentTaskbar.Handle;
 
                 // set up thumbnail

--- a/Cairo Desktop/Cairo Desktop/TaskThumbnail.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/TaskThumbnail.xaml.cs
@@ -1,10 +1,8 @@
 ﻿using CairoDesktop.Configuration;
-using CairoDesktop.SupportingClasses;
 using ManagedShell.Common.Helpers;
 using ManagedShell.Interop;
 using ManagedShell.WindowsTasks;
 using System;
-using System.Collections.ObjectModel;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;

--- a/Cairo Desktop/Cairo Desktop/Taskbar.xaml
+++ b/Cairo Desktop/Cairo Desktop/Taskbar.xaml
@@ -6,6 +6,7 @@
     x:Class="CairoDesktop.Taskbar"
     xmlns:self="clr-namespace:CairoDesktop"
     xmlns:l10n="clr-namespace:CairoDesktop.Localization;assembly=CairoDesktop.Localization"
+    xmlns:settings="clr-namespace:CairoDesktop.Configuration;assembly=CairoDesktop.Configuration"
     xmlns:support="clr-namespace:CairoDesktop.SupportingClasses"
     x:Name="TaskbarWindow"
     Left="0"
@@ -19,7 +20,9 @@
     HorizontalAlignment="Center">
     <Window.Resources>
         <ResourceDictionary>
+            <support:TaskGroupConverter x:Key="groupConverter" />
             <support:TaskGroupNameConverter x:Key="groupNameConverter" />
+            <support:TaskGroupSizeConverter x:Key="groupSizeConverter" />
         </ResourceDictionary>
     </Window.Resources>
     <Border Name="bdrBackground">
@@ -407,6 +410,31 @@
                                                     </ControlTemplate>
                                                 </Setter.Value>
                                             </Setter>
+                                            <Style.Triggers>
+                                                <MultiDataTrigger>
+                                                    <MultiDataTrigger.Conditions>
+                                                        <Condition Binding="{Binding Path=ItemCount, Converter={StaticResource groupSizeConverter}}"
+                                                                   Value="True" />
+                                                        <Condition Binding="{Binding Source={x:Static settings:Settings.Instance}, Path=TaskbarGroupingStyle, UpdateSourceTrigger=PropertyChanged}"
+                                                                   Value="2" />
+                                                    </MultiDataTrigger.Conditions>
+                                                    <MultiDataTrigger.Setters>
+                                                        <Setter Property="Template">
+                                                            <Setter.Value>
+                                                                <ControlTemplate TargetType="GroupItem">
+                                                                    <ContentControl Style="{StaticResource TaskbarGroup}">
+                                                                        <self:TaskButton ListMode="False"
+                                                                                         ParentTaskbar="{Binding ElementName=TaskbarWindow}"
+                                                                                         Width="{Binding Path=ButtonWidth, ElementName=TaskbarWindow}"
+                                                                                         Margin="0,0,-1,0"
+                                                                                         DataContext="{Binding Converter={StaticResource groupConverter}}" />
+                                                                    </ContentControl>
+                                                                </ControlTemplate>
+                                                            </Setter.Value>
+                                                        </Setter>
+                                                    </MultiDataTrigger.Setters>
+                                                </MultiDataTrigger>
+                                            </Style.Triggers>
                                         </Style>
                                     </GroupStyle.ContainerStyle>
                                 </GroupStyle>

--- a/Cairo Desktop/Cairo Desktop/Taskbar.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/Taskbar.xaml.cs
@@ -115,11 +115,11 @@ namespace CairoDesktop
         {
             if (Settings.Instance.TaskbarGroupingStyle == 0)
             {
-                return new ApplicationTaskCategoryProvider();
+                return new AppGrabberTaskCategoryProvider(_appGrabber, _shellManager);
             }
             else
             {
-                return new AppGrabberTaskCategoryProvider(_appGrabber, _shellManager);
+                return new ApplicationTaskCategoryProvider();
             }
         }
 

--- a/Cairo Desktop/Cairo Desktop/Taskbar.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/Taskbar.xaml.cs
@@ -113,7 +113,7 @@ namespace CairoDesktop
 
         private ITaskCategoryProvider getTaskCategoryProvider()
         {
-            if (Settings.Instance.TaskbarGroupingStyle == 1)
+            if (Settings.Instance.TaskbarGroupingStyle == 0)
             {
                 return new ApplicationTaskCategoryProvider();
             }

--- a/Cairo Desktop/Cairo Desktop/Themes/Cairo.xaml
+++ b/Cairo Desktop/Cairo Desktop/Themes/Cairo.xaml
@@ -1722,6 +1722,15 @@
         <Setter Property="Margin"
                 Value="5,0,5,0" />
     </Style>
+    <Style x:Key="TaskbarButtonOverlayPanel"
+           TargetType="{x:Type StackPanel}">
+        <Setter Property="Margin"
+                Value="0,0,3,3" />
+        <Setter Property="HorizontalAlignment"
+                Value="Right" />
+        <Setter Property="VerticalAlignment"
+                Value="Bottom" />
+    </Style>
     <Style x:Key="TaskListIcon"
            TargetType="{x:Type Image}"
            BasedOn="{StaticResource TaskbarButtonIcon}">

--- a/Cairo Desktop/CairoDesktop.Common/CairoDesktop.Common.csproj
+++ b/Cairo Desktop/CairoDesktop.Common/CairoDesktop.Common.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedShell" Version="0.0.134" />
+    <PackageReference Include="ManagedShell" Version="0.0.136" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
   </ItemGroup>

--- a/Cairo Desktop/CairoDesktop.Localization/DisplayString.cs
+++ b/Cairo Desktop/CairoDesktop.Localization/DisplayString.cs
@@ -596,6 +596,8 @@ namespace CairoDesktop.Localization
 
         public static string sSettings_Taskbar_GroupByApplication => getString();
 
+        public static string sSettings_Taskbar_GroupByApplicationCombined => getString();
+
         public static string sSettings_Taskbar_ShowBadges => getString();
 
         public static string sSettings_Taskbar_ShowLabels => getString();

--- a/Cairo Desktop/CairoDesktop.Localization/Language.cs
+++ b/Cairo Desktop/CairoDesktop.Localization/Language.cs
@@ -252,6 +252,7 @@ namespace CairoDesktop.Localization
             { "sSettings_Taskbar_GroupBy", "Group windows by:" },
             { "sSettings_Taskbar_GroupByProgramsMenuCategory", "Programs menu category" },
             { "sSettings_Taskbar_GroupByApplication", "Application" },
+            { "sSettings_Taskbar_GroupByApplicationCombined", "Application (combined)" },
             { "sSettings_Taskbar_ShowBadges", "Show badges" },
             { "sSettings_Taskbar_ShowLabels", "Show labels" },
             { "sSettings_Taskbar_EnableThumbnails", "Show window thumbnails" },


### PR DESCRIPTION
When enabled, and there are multiple windows associated to an app, the taskbar will display a single TaskButton bound to a TaskGroup rather than a group of multiple TaskButtons bound to individual ApplicationWindows.

TaskGroup is an object that contains a list of ApplicationWindows, and has the same properties as an ApplicationWindow for binding. Its icon and title comes not from a window but from the application the windows are from. Task progress is averaged across all windows in the group with progress, and the task overlay icon is used from the first window that has one (that is similar to the logic Windows uses from what I could tell).

TaskThumbWindow was refactored to support showing a collection of windows from the TaskGroup, by moving the thumbnail into a separate UserControl.

Also included some drive-by fixes where we weren't treating UWP windows correctly for opening a new instance, and fixes a regression with taskbar badge layout.

This should fix our oldest bug, #52!