### PR TITLE
Allow running capable UWP apps as admin

### DIFF
--- a/Cairo Desktop/Cairo Desktop/Cairo Desktop.csproj
+++ b/Cairo Desktop/Cairo Desktop/Cairo Desktop.csproj
@@ -67,7 +67,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedShell" Version="0.0.140" />
+    <PackageReference Include="ManagedShell" Version="0.0.142" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />

--- a/Cairo Desktop/Cairo Desktop/MenuBar.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/MenuBar.xaml.cs
@@ -18,7 +18,7 @@ using ManagedShell.AppBar;
 using ManagedShell.Common.Helpers;
 using ManagedShell.Common.Logging;
 using ManagedShell.Interop;
-using ManagedShell.ShellFolders.Enums;
+using ManagedShell.Common.Enums;
 using NativeMethods = ManagedShell.Interop.NativeMethods;
 
 namespace CairoDesktop

--- a/Cairo Desktop/Cairo Desktop/ProgramsMenu.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/ProgramsMenu.xaml.cs
@@ -116,7 +116,7 @@ namespace CairoDesktop
             MenuItem item = (MenuItem)sender;
             ApplicationInfo app = item.DataContext as ApplicationInfo;
 
-            MenuBar._appGrabber.AddToQuickLaunch(app);
+            MenuBar._appGrabber.QuickLaunchManager.AddToQuickLaunch(app);
         }
 
         private void programsMenu_Rename(object sender, RoutedEventArgs e)

--- a/Cairo Desktop/Cairo Desktop/ProgramsMenu.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/ProgramsMenu.xaml.cs
@@ -76,7 +76,7 @@ namespace CairoDesktop
                 switch (item.Name)
                 {
                     case "miProgramsItemAdmin":
-                        item.Visibility = app.IsStoreApp ? Visibility.Collapsed : Visibility.Visible;
+                        item.Visibility = app.AllowRunAsAdmin ? Visibility.Visible : Visibility.Collapsed;
                         break;
                     case "miProgramsItemRunAs":
                         item.Visibility = KeyboardUtilities.IsKeyDown(System.Windows.Forms.Keys.ShiftKey) && !app.IsStoreApp ? Visibility.Visible : Visibility.Collapsed;

--- a/Cairo Desktop/Cairo Desktop/QuickLaunchButton.xaml
+++ b/Cairo Desktop/Cairo Desktop/QuickLaunchButton.xaml
@@ -26,11 +26,17 @@
                    Width="16"
                    Height="16" />
             <Button.ContextMenu>
-                <ContextMenu Closed="ContextMenu_Closed">
+                <ContextMenu Closed="ContextMenu_Closed"
+                             Opened="ContextMenu_Opened">
                     <MenuItem Header="{Binding Path=(l10n:DisplayString.sInterface_Open)}" 
-                              Click="LaunchProgramMenu" />
+                              Click="programsMenu_Open" />
                     <MenuItem Header="{Binding Path=(l10n:DisplayString.sInterface_OpenAsAdministrator)}" 
-                              Click="LaunchProgramAdmin" />
+                              Name="miProgramsItemAdmin"
+                              Click="programsMenu_OpenAsAdmin" />
+                    <MenuItem Header="{Binding Path=(l10n:DisplayString.sInterface_RunAsUser)}"
+                              Click="programsMenu_OpenRunAs"
+                              Visibility="Collapsed"
+                              Name="miProgramsItemRunAs" />
                     <Separator />
                     <MenuItem Header="{Binding Path=(l10n:DisplayString.sInterface_Rename)}" 
                               Click="programsMenu_Rename" />

--- a/Cairo Desktop/Cairo Desktop/QuickLaunchButton.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/QuickLaunchButton.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using CairoDesktop.AppGrabber;
+using CairoDesktop.Common;
 using CairoDesktop.Configuration;
 using ManagedShell.Common.Helpers;
 
@@ -55,7 +56,7 @@ namespace CairoDesktop
             ParentTaskbar._appGrabber.LaunchProgram(app);
         }
 
-        private void LaunchProgramMenu(object sender, RoutedEventArgs e)
+        private void programsMenu_Open(object sender, RoutedEventArgs e)
         {
             MenuItem item = (MenuItem)sender;
             ApplicationInfo app = item.DataContext as ApplicationInfo;
@@ -63,12 +64,20 @@ namespace CairoDesktop
             ParentTaskbar._appGrabber.LaunchProgram(app);
         }
 
-        private void LaunchProgramAdmin(object sender, RoutedEventArgs e)
+        private void programsMenu_OpenAsAdmin(object sender, RoutedEventArgs e)
         {
             MenuItem item = (MenuItem)sender;
             ApplicationInfo app = item.DataContext as ApplicationInfo;
 
             ParentTaskbar._appGrabber.LaunchProgramAdmin(app);
+        }
+
+        private void programsMenu_OpenRunAs(object sender, RoutedEventArgs e)
+        {
+            MenuItem item = (MenuItem)sender;
+            ApplicationInfo app = item.DataContext as ApplicationInfo;
+
+            ParentTaskbar._appGrabber.LaunchProgramVerb(app, "runasuser");
         }
 
         private void programsMenu_Remove(object sender, RoutedEventArgs e)
@@ -195,6 +204,28 @@ namespace CairoDesktop
         private void setParentAutoHide(bool enabled)
         {
             if (ParentTaskbar != null) ParentTaskbar.CanAutoHide = enabled;
+        }
+
+        private void ContextMenu_Opened(object sender, RoutedEventArgs e)
+        {
+            ContextMenu menu = sender as ContextMenu;
+
+            foreach (Control item in menu.Items)
+            {
+                ApplicationInfo app = item.DataContext as ApplicationInfo;
+
+                switch (item.Name)
+                {
+                    case "miProgramsItemAdmin":
+                        item.Visibility = app.AllowRunAsAdmin ? Visibility.Visible : Visibility.Collapsed;
+                        break;
+                    case "miProgramsItemRunAs":
+                        item.Visibility = KeyboardUtilities.IsKeyDown(System.Windows.Forms.Keys.ShiftKey) && !app.IsStoreApp ? Visibility.Visible : Visibility.Collapsed;
+                        break;
+                    default:
+                        break;
+                }
+            }
         }
     }
 }

--- a/Cairo Desktop/Cairo Desktop/TaskButton.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/TaskButton.xaml.cs
@@ -378,7 +378,7 @@ namespace CairoDesktop
 
             if (toPin != null)
             {
-                ParentTaskbar._appGrabber.QuickLaunchManager.PinToQuickLaunch(toPin.IsUWP, toPin.IsUWP ? toPin.AppUserModelID : toPin.WinFileName);
+                ParentTaskbar._appGrabber.QuickLaunchManager.AddToQuickLaunch(toPin.IsUWP, toPin.IsUWP ? toPin.AppUserModelID : toPin.WinFileName);
             }
         }
 

--- a/Cairo Desktop/CairoDesktop.AppGrabber/AppGrabberService.cs
+++ b/Cairo Desktop/CairoDesktop.AppGrabber/AppGrabberService.cs
@@ -542,21 +542,6 @@ namespace CairoDesktop.AppGrabber
             }
         }
 
-        public void AddToQuickLaunch(ApplicationInfo app)
-        {
-            if (QuickLaunch.Contains(app))
-            {
-                return;
-            }
-
-            ApplicationInfo appClone = app.Clone();
-            appClone.Icon = null;
-
-            QuickLaunch.Add(appClone);
-
-            Save();
-        }
-
         public void Dispose()
         {
             // no work to do here
@@ -573,7 +558,6 @@ namespace CairoDesktop.AppGrabber
         void AddByPath(string[] fileNames, AppCategoryType categoryType);
         void AddByPath(string fileName, AppCategoryType categoryType);
         void AddStoreApp(string appUserModelId, AppCategoryType categoryType);
-        void AddToQuickLaunch(ApplicationInfo app);
         void InsertByPath(string[] fileNames, int index, AppCategoryType categoryType);
         void LaunchProgram(ApplicationInfo app);
         void LaunchProgramAdmin(ApplicationInfo app);

--- a/Cairo Desktop/CairoDesktop.AppGrabber/ApplicationInfo.cs
+++ b/Cairo Desktop/CairoDesktop.AppGrabber/ApplicationInfo.cs
@@ -28,13 +28,14 @@ namespace CairoDesktop.AppGrabber
         /// <param name="path">Path to the shortcut.</param>
         /// <param name="target">Path to the executable.</param>
         /// <param name="icon">ImageSource used to denote the application's icon in a graphical environment.</param>
-        public ApplicationInfo(string name, string path, string target, ImageSource icon, string iconColor)
+        public ApplicationInfo(string name, string path, string target, ImageSource icon, string iconColor, bool allowRunAsAdmin)
         {
             Name = name;
             Path = path;
             Target = target;
             Icon = icon;
             IconColor = iconColor;
+            AllowRunAsAdmin = allowRunAsAdmin;
         }
 
         private bool _iconLoading;
@@ -117,6 +118,20 @@ namespace CairoDesktop.AppGrabber
             set
             {
                 iconColor = value;
+                OnPropertyChanged();
+            }
+        }
+
+        private bool allowRunAsAdmin;
+        /// <summary>
+        /// If the application allows the user to run it as an administrator.
+        /// </summary>
+        public bool AllowRunAsAdmin
+        {
+            get { return allowRunAsAdmin; }
+            set
+            {
+                allowRunAsAdmin = value;
                 OnPropertyChanged();
             }
         }
@@ -316,6 +331,7 @@ namespace CairoDesktop.AppGrabber
             ai.Path = "appx:" + storeApp.AppUserModelId;
             ai.Target = storeApp.AppUserModelId;
             ai.IconColor = storeApp.IconColor;
+            ai.AllowRunAsAdmin = storeApp.EntryPoint == "Windows.FullTrustApplication";
 
             return ai;
         }
@@ -326,7 +342,7 @@ namespace CairoDesktop.AppGrabber
         /// <returns>A new ApplicationInfo object with the same data as this object, not bound to a Category.</returns>
         internal ApplicationInfo Clone()
         {
-            ApplicationInfo rval = new ApplicationInfo(Name, Path, Target, Icon, IconColor);
+            ApplicationInfo rval = new ApplicationInfo(Name, Path, Target, Icon, IconColor, AllowRunAsAdmin);
             return rval;
         }
 

--- a/Cairo Desktop/CairoDesktop.AppGrabber/ApplicationInfo.cs
+++ b/Cairo Desktop/CairoDesktop.AppGrabber/ApplicationInfo.cs
@@ -38,6 +38,7 @@ namespace CairoDesktop.AppGrabber
             AllowRunAsAdmin = allowRunAsAdmin;
         }
 
+        #region Properties
         private bool _iconLoading;
 
         private string name;
@@ -215,63 +216,6 @@ namespace CairoDesktop.AppGrabber
                 OnPropertyChanged();
             }
         }
-
-        #region IEquatable
-        /// <summary>
-        /// Determines if this ApplicationInfo object refers to the same application as another ApplicationInfo object.
-        /// </summary>
-        /// <param name="other">ApplicationInfo object to compare to.</param>
-        /// <returns>True if the Name and Path values are equal, False if not.</returns>
-        public bool Equals(ApplicationInfo other)
-        {
-            //if (this.Name != other.Name) return false; -- because apps can be renamed, this is no longer valid
-            if (Path == other.Path)
-            {
-                return true;
-            }
-            if (System.IO.Path.GetExtension(Path).Equals(".lnk", StringComparison.OrdinalIgnoreCase))
-            {
-                if (Target == other.Target && Name == other.Name)
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        /// <summary>
-        /// Determines if this ApplicationInfo object refers to the same application as another ApplicationInfo object.
-        /// </summary>
-        /// <param name="obj">Object to compare to.</param>
-        /// <returns>True if the Name and Path values are equal, False if not.</returns>
-        public override bool Equals(object obj)
-        {
-            if (!(obj is ApplicationInfo))
-                return false;
-            return Equals((ApplicationInfo)obj);
-        }
-
-        public override int GetHashCode()
-        {
-            int hashCode = 0;
-            if (Name != null)
-                hashCode ^= Name.GetHashCode();
-            if (Path != null)
-                hashCode ^= Path.GetHashCode();
-            return hashCode;
-        }
-        #endregion
-
-        #region IComparable
-        /// <summary>
-        /// Is this object greater than, less than, or equal to another ApplicationInfo? (For sorting purposes only)
-        /// </summary>
-        /// <param name="other">Object to compare to.</param>
-        /// <returns>0 if same, negative if less, positive if more.</returns>
-        public int CompareTo(ApplicationInfo other)
-        {
-            return Name.CompareTo(other.Name);
-        }
         #endregion
 
         public override string ToString()
@@ -345,6 +289,64 @@ namespace CairoDesktop.AppGrabber
             ApplicationInfo rval = new ApplicationInfo(Name, Path, Target, Icon, IconColor, AllowRunAsAdmin);
             return rval;
         }
+
+        #region IEquatable
+        /// <summary>
+        /// Determines if this ApplicationInfo object refers to the same application as another ApplicationInfo object.
+        /// </summary>
+        /// <param name="other">ApplicationInfo object to compare to.</param>
+        /// <returns>True if the Name and Path values are equal, False if not.</returns>
+        public bool Equals(ApplicationInfo other)
+        {
+            //if (this.Name != other.Name) return false; -- because apps can be renamed, this is no longer valid
+            if (Path == other.Path)
+            {
+                return true;
+            }
+            if (System.IO.Path.GetExtension(Path).Equals(".lnk", StringComparison.OrdinalIgnoreCase))
+            {
+                if (Target == other.Target && Name == other.Name)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Determines if this ApplicationInfo object refers to the same application as another ApplicationInfo object.
+        /// </summary>
+        /// <param name="obj">Object to compare to.</param>
+        /// <returns>True if the Name and Path values are equal, False if not.</returns>
+        public override bool Equals(object obj)
+        {
+            if (!(obj is ApplicationInfo))
+                return false;
+            return Equals((ApplicationInfo)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = 0;
+            if (Name != null)
+                hashCode ^= Name.GetHashCode();
+            if (Path != null)
+                hashCode ^= Path.GetHashCode();
+            return hashCode;
+        }
+        #endregion
+
+        #region IComparable
+        /// <summary>
+        /// Is this object greater than, less than, or equal to another ApplicationInfo? (For sorting purposes only)
+        /// </summary>
+        /// <param name="other">Object to compare to.</param>
+        /// <returns>0 if same, negative if less, positive if more.</returns>
+        public int CompareTo(ApplicationInfo other)
+        {
+            return Name.CompareTo(other.Name);
+        }
+        #endregion
 
         #region INotifyPropertyChanged
         public event PropertyChangedEventHandler PropertyChanged;

--- a/Cairo Desktop/CairoDesktop.AppGrabber/CategoryList.cs
+++ b/Cairo Desktop/CairoDesktop.AppGrabber/CategoryList.cs
@@ -149,29 +149,41 @@ namespace CairoDesktop.AppGrabber {
                     XmlAttribute catNameAttribute = doc.CreateAttribute("Name");
                     catNameAttribute.Value = cat.Name;
                     catElement.Attributes.Append(catNameAttribute);
+
                     XmlAttribute catShowInMenuAttribute = doc.CreateAttribute("ShowInMenu");
                     catShowInMenuAttribute.Value = cat.ShowInMenu.ToString();
                     catElement.Attributes.Append(catShowInMenuAttribute);
+
                     XmlAttribute catTypeAttribute = doc.CreateAttribute("Type");
                     catTypeAttribute.Value = ((int)cat.Type).ToString();
                     catElement.Attributes.Append(catTypeAttribute);
+
                     root.AppendChild(catElement);
                     foreach (ApplicationInfo app in cat)
                     {
                         XmlElement appElement = doc.CreateElement("Application");
                         catElement.AppendChild(appElement);
+
                         XmlAttribute appAskAlwaysAdminAttribute = doc.CreateAttribute("AskAlwaysAdmin");
                         appAskAlwaysAdminAttribute.Value = app.AskAlwaysAdmin.ToString();
                         appElement.Attributes.Append(appAskAlwaysAdminAttribute);
+
                         XmlAttribute appAlwaysAdminAttribute = doc.CreateAttribute("AlwaysAdmin");
                         appAlwaysAdminAttribute.Value = app.AlwaysAdmin.ToString();
                         appElement.Attributes.Append(appAlwaysAdminAttribute);
+
+                        XmlAttribute appAllowRunAsAdminAttribute = doc.CreateAttribute("AllowRunAsAdmin");
+                        appAllowRunAsAdminAttribute.Value = app.AllowRunAsAdmin.ToString();
+                        appElement.Attributes.Append(appAllowRunAsAdminAttribute);
+
                         XmlElement appNameElement = doc.CreateElement("Name");
                         appNameElement.InnerText = app.Name;
                         appElement.AppendChild(appNameElement);
+
                         XmlElement pathElement = doc.CreateElement("Path");
                         pathElement.InnerText = app.Path;
                         appElement.AppendChild(pathElement);
+
                         XmlElement targetElement = doc.CreateElement("Target");
                         targetElement.InnerText = app.Target;
                         appElement.AppendChild(targetElement);
@@ -232,7 +244,23 @@ namespace CairoDesktop.AppGrabber {
                         ShellLogger.Debug(app.Path + " does not exist");
                         continue;
                     }
-                    
+
+                    if (appElement.Attributes["AllowRunAsAdmin"] != null)
+                        app.AllowRunAsAdmin = Convert.ToBoolean(appElement.Attributes["AllowRunAsAdmin"].Value);
+                    else
+                    {
+                        // migration
+                        if (app.IsStoreApp && EnvironmentHelper.IsWindows8OrBetter)
+                        {
+                            ManagedShell.UWPInterop.StoreApp storeApp = ManagedShell.UWPInterop.StoreAppHelper.AppList.GetAppByAumid(app.Target);
+                            app.AllowRunAsAdmin = storeApp.EntryPoint == "Windows.FullTrustApplication";
+                        }
+                        else
+                        {
+                            app.AllowRunAsAdmin = true;
+                        }
+                    }
+
                     cat.Add(app);
                 }
             }

--- a/Cairo Desktop/CairoDesktop.AppGrabber/QuickLaunchManager.cs
+++ b/Cairo Desktop/CairoDesktop.AppGrabber/QuickLaunchManager.cs
@@ -30,7 +30,7 @@ namespace CairoDesktop.AppGrabber
             return null;
         }
 
-        public void PinToQuickLaunch(bool isUWP, string path)
+        public void AddToQuickLaunch(bool isUWP, string path)
         {
             if (isUWP)
             {
@@ -39,8 +39,23 @@ namespace CairoDesktop.AppGrabber
             }
             else
             {
-                _appGrabber.AddByPath(new[] { path }, AppCategoryType.QuickLaunch);
+                _appGrabber.AddByPath(path, AppCategoryType.QuickLaunch);
             }
+        }
+
+        public void AddToQuickLaunch(ApplicationInfo app)
+        {
+            if (_appGrabber.QuickLaunch.Contains(app))
+            {
+                return;
+            }
+
+            ApplicationInfo appClone = app.Clone();
+            appClone.Icon = null;
+
+            _appGrabber.QuickLaunch.Add(appClone);
+
+            _appGrabber.Save();
         }
     }
 }

--- a/Cairo Desktop/CairoDesktop.Common/CairoDesktop.Common.csproj
+++ b/Cairo Desktop/CairoDesktop.Common/CairoDesktop.Common.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedShell" Version="0.0.140" />
+    <PackageReference Include="ManagedShell" Version="0.0.142" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
   </ItemGroup>


### PR DESCRIPTION
- Refactored AppGrabberService to reduce nesting
- Saves if app allows run as admin to config file with migration process
- Fixed admin dialog not saving
- Fixed quick launch context menu not hiding admin option
- Fixed quick launch context menu not having run as user option

Fixes #605.