### PR TITLE
Use percentage for desktop toolbar positioning

### DIFF
--- a/Cairo Desktop/Cairo Desktop/DesktopNavigationToolbar.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/DesktopNavigationToolbar.xaml.cs
@@ -137,7 +137,7 @@ namespace CairoDesktop
         {
             bool result = false;
 
-            if (System.Windows.Forms.Screen.AllScreens.Any(s => s.Bounds.Contains((int)desktopNavigationToolbarLocation.X, (int)desktopNavigationToolbarLocation.Y)))
+            if (System.Windows.Forms.Screen.AllScreens.Any(s => s.Bounds.Contains((int)(desktopNavigationToolbarLocation.X * DpiHelper.DpiScale), (int)(desktopNavigationToolbarLocation.Y * DpiHelper.DpiScale))))
             {
                 result = true;
             }


### PR DESCRIPTION
The current absolute positioning method can be annoying, as when screen sizes change (such as RDP), the toolbar ends up in the wrong place. By using percentages, this doesn't occur.

Note that I didn't add migration for the setting. Whatever is saved from the old absolute positioning scheme will fail the bounds check and result in the default position being used. When the user moves it back to the desired location, the percentage will save. @josuave does this sound OK? Adding migration didn't seem worth it here, but open to adding it if needed.