### PR TITLE
Add null check to UWP admin migration (#644)

### DIFF
--- a/Cairo Desktop/CairoDesktop.AppGrabber/CategoryList.cs
+++ b/Cairo Desktop/CairoDesktop.AppGrabber/CategoryList.cs
@@ -253,7 +253,15 @@ namespace CairoDesktop.AppGrabber {
                         if (app.IsStoreApp && EnvironmentHelper.IsWindows8OrBetter)
                         {
                             ManagedShell.UWPInterop.StoreApp storeApp = ManagedShell.UWPInterop.StoreAppHelper.AppList.GetAppByAumid(app.Target);
-                            app.AllowRunAsAdmin = storeApp.EntryPoint == "Windows.FullTrustApplication";
+
+                            if (storeApp != null)
+                            {
+                                app.AllowRunAsAdmin = storeApp.EntryPoint == "Windows.FullTrustApplication";
+                            }
+                            else
+                            {
+                                app.AllowRunAsAdmin = false;
+                            }
                         }
                         else
                         {


### PR DESCRIPTION
Fixes crash with a saved UWP app that no longer exists