### PR TITLE
Fix stuck progress when window is destroyed before updating progress value

### DIFF
--- a/Cairo Desktop/Cairo Desktop/SupportingClasses/TaskGroup.cs
+++ b/Cairo Desktop/Cairo Desktop/SupportingClasses/TaskGroup.cs
@@ -341,6 +341,13 @@ namespace CairoDesktop.SupportingClasses
                         appWindow.PropertyChanged -= ApplicationWindow_PropertyChanged;
                     }
                 }
+
+                if (e.OldItems.Count > 0)
+                {
+                    // If windows were removed, update progress values in case the window was destroyed before updating its progress value
+                    OnPropertyChanged("ProgressState");
+                    OnPropertyChanged("ProgressValue");
+                }
             }
 
             // If the window count has changed such that single window mode should toggle


### PR DESCRIPTION
Occurs with file explorer in combined task group mode.