### PR TITLE
Expand environment variables in go to folder window

### DIFF
--- a/Cairo Desktop/Cairo Desktop/DesktopNavigationToolbar.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/DesktopNavigationToolbar.xaml.cs
@@ -359,7 +359,7 @@ namespace CairoDesktop
                 Localization.DisplayString.sInterface_Cancel,
                 (bool? result) =>
                 {
-                    string path = inputControl.InputField.Text;
+                    string path = Environment.ExpandEnvironmentVariables(inputControl.InputField.Text);
                     if (result != true || string.IsNullOrEmpty(path))
                     {
                         return;


### PR DESCRIPTION
Allows going to, for example, `%localappdata%` from the desktop toolbar.