### PR TITLE
Balloon notifications support

### DIFF
--- a/Cairo Desktop/Cairo Desktop/Taskbar.xaml
+++ b/Cairo Desktop/Cairo Desktop/Taskbar.xaml
@@ -432,7 +432,11 @@
                                                                                                              From="0"
                                                                                                              To="{Binding Path=ButtonWidth, ElementName=TaskbarWindow}"
                                                                                                              Duration="0:0:0.2"
-                                                                                                             FillBehavior="Stop" />
+                                                                                                             FillBehavior="Stop">
+                                                                                                <DoubleAnimation.EasingFunction>
+                                                                                                    <QuadraticEase EasingMode="EaseInOut" />
+                                                                                                </DoubleAnimation.EasingFunction>
+                                                                                            </DoubleAnimation>
                                                                                         </Storyboard>
                                                                                     </BeginStoryboard>
                                                                                 </EventTrigger>
@@ -479,7 +483,11 @@
                                                                                      From="0"
                                                                                      To="{Binding Path=ButtonWidth, ElementName=TaskbarWindow}"
                                                                                      Duration="0:0:0.2"
-                                                                                     FillBehavior="Stop" />
+                                                                                     FillBehavior="Stop">
+                                                                        <DoubleAnimation.EasingFunction>
+                                                                            <QuadraticEase EasingMode="EaseInOut" />
+                                                                        </DoubleAnimation.EasingFunction>
+                                                                    </DoubleAnimation>
                                                                 </Storyboard>
                                                             </BeginStoryboard>
                                                         </EventTrigger>

--- a/Cairo Desktop/Cairo Desktop/Themes/Cairo.xaml
+++ b/Cairo Desktop/Cairo Desktop/Themes/Cairo.xaml
@@ -3935,19 +3935,71 @@
             </DataTrigger>
         </Style.Triggers>
     </Style>
+    <Style x:Key="NotifyIconPanel"
+           TargetType="StackPanel">
+        <Setter Property="Background"
+                Value="{DynamicResource NotifyBalloonBackground}" />
+        <Setter Property="Margin"
+                Value="5,0" />
+        <Setter Property="Orientation"
+                Value="Horizontal" />
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Path=Balloon, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                         Value="{x:Null}">
+                <Setter Property="Background"
+                        Value="Transparent" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
     <Style x:Key="NotifyIconImage"
            TargetType="Image">
         <Setter Property="Margin"
-                Value="5,0,5,2" />
+                Value="0,0,0,1" />
         <Setter Property="Height"
                 Value="16" />
         <Setter Property="Width"
                 Value="16" />
     </Style>
-    <Style x:Key="NotifyIconBalloonPanel"
-           TargetType="DockPanel">
-        <Setter Property="Margin"
-                Value="0,0,5,0" />
+    <Style x:Key="NotifyIconBalloonAnimatedBorder"
+           TargetType="Border">
+        <Setter Property="Visibility"
+                Value="Collapsed" />
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Path=Balloon, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                         Value="{x:Null}">
+                <DataTrigger.EnterActions>
+                    <BeginStoryboard>
+                        <Storyboard>
+                            <DoubleAnimation Storyboard.TargetProperty="Width"
+                                             To="0"
+                                             Duration="0:0:0.2">
+                                <DoubleAnimation.EasingFunction>
+                                    <QuadraticEase EasingMode="EaseInOut" />
+                                </DoubleAnimation.EasingFunction>
+                            </DoubleAnimation>
+                        </Storyboard>
+                    </BeginStoryboard>
+                </DataTrigger.EnterActions>
+                <DataTrigger.ExitActions>
+                    <BeginStoryboard>
+                        <Storyboard>
+                            <DoubleAnimation Storyboard.TargetProperty="Width"
+                                             To="1"
+                                             Duration="0:0:0.2">
+                                <DoubleAnimation.EasingFunction>
+                                    <QuadraticEase EasingMode="EaseInOut" />
+                                </DoubleAnimation.EasingFunction>
+                            </DoubleAnimation>
+                        </Storyboard>
+                    </BeginStoryboard>
+                </DataTrigger.ExitActions>
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+    <Style x:Key="NotifyIconBalloonInlineBorder"
+           TargetType="Border">
+        <Setter Property="Background"
+                Value="Transparent" />
         <Setter Property="Visibility"
                 Value="Visible" />
         <Style.Triggers>
@@ -3958,18 +4010,25 @@
             </DataTrigger>
         </Style.Triggers>
     </Style>
-    <Style x:Key="NotifyIconBalloonCloseButton"
+    <Style x:Key="NotifyIconBalloonInlinePanel"
+           TargetType="StackPanel">
+        <Setter Property="Orientation"
+                Value="Horizontal" />
+    </Style>
+    <Style x:Key="NotifyIconBalloonInlineCloseButton"
            TargetType="Button">
         <Setter Property="Effect"
                 Value="{DynamicResource ResourceKey=MenuHeaderShadow}" />
         <Setter Property="OverridesDefaultStyle"
-            Value="true" />
+                Value="true" />
         <Setter Property="FontFamily"
                 Value="Webdings" />
         <Setter Property="FontSize"
                 Value="12" />
         <Setter Property="Foreground"
                 Value="{DynamicResource MenuHeaderForeground}" />
+        <Setter Property="Opacity"
+                Value="0.5" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
@@ -3990,6 +4049,8 @@
                                           BlurRadius="7" />
                     </Setter.Value>
                 </Setter>
+                <Setter Property="Opacity"
+                        Value="1" />
             </Trigger>
             <Trigger Property="IsPressed"
                      Value="True">
@@ -4001,10 +4062,12 @@
                                           BlurRadius="7" />
                     </Setter.Value>
                 </Setter>
+                <Setter Property="Opacity"
+                        Value="1" />
             </Trigger>
         </Style.Triggers>
     </Style>
-    <Style x:Key="NotifyIconBalloonTitle"
+    <Style x:Key="NotifyIconBalloonInlineTitle"
            TargetType="TextBlock">
         <Setter Property="Effect"
                 Value="{DynamicResource ResourceKey=MenuHeaderShadow}" />
@@ -4013,31 +4076,13 @@
         <Setter Property="FontSize"
                 Value="{DynamicResource SmallFontSize}" />
         <Setter Property="Margin"
-                Value="0,-1,0,2" />
-        <Setter Property="Width"
+                Value="5,-1,5,2" />
+        <Setter Property="MaxWidth"
                 Value="120" />
-        <Setter Property="Padding"
-                Value="0,0,5,0" />
         <Setter Property="TextTrimming"
                 Value="CharacterEllipsis" />
         <Setter Property="VerticalAlignment"
                 Value="Center" />
-        <Style.Triggers>
-            <DataTrigger Binding="{Binding Path=Balloon, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                         Value="{x:Null}">
-                <DataTrigger.ExitActions>
-                    <BeginStoryboard>
-                        <Storyboard>
-                            <DoubleAnimation Storyboard.TargetProperty="Width"
-                                             From="0"
-                                             To="120"
-                                             Duration="0:0:0.2"
-                                             FillBehavior="Stop" />
-                        </Storyboard>
-                    </BeginStoryboard>
-                </DataTrigger.ExitActions>
-            </DataTrigger>
-        </Style.Triggers>
     </Style>
     <Style x:Key="NotifyIconBalloonContent"
            TargetType="TextBlock">
@@ -4048,7 +4093,7 @@
         <Setter Property="TextWrapping"
                 Value="Wrap" />
     </Style>
-    <Style x:Key="NotifyIconBalloonContentTitle"
+    <Style x:Key="NotifyIconBalloonTitle"
            TargetType="TextBlock"
            BasedOn="{StaticResource NotifyIconBalloonContent}">
         <Setter Property="FontWeight"

--- a/Cairo Desktop/Cairo Desktop/Themes/Cairo.xaml
+++ b/Cairo Desktop/Cairo Desktop/Themes/Cairo.xaml
@@ -99,6 +99,14 @@
     <Thickness x:Key="MenuBarBorderThickness" Bottom="1" />
     <SolidColorBrush Color="#FF9a9a9a"
                      x:Key="NoItemsForeground" />
+    <RadialGradientBrush x:Key="NotifyBalloonBackground"
+                         Center="0.5,1"
+                         GradientOrigin="0.5,1">
+        <GradientStop Color="#91ff8400"
+                      Offset="0.0" />
+        <GradientStop Color="#00ff8400"
+                      Offset="1.0" />
+    </RadialGradientBrush>
 
 
     <!-- Search resources -->
@@ -3917,17 +3925,8 @@
     <!-- Styles for notification area and balloon notifications -->
     <Style x:Key="NotifyIconBorder"
            TargetType="Border">
-        <Setter Property="Background">
-            <Setter.Value>
-                <LinearGradientBrush StartPoint="0,0"
-                                     EndPoint="0,1">
-                    <GradientStop Color="#00000000"
-                                  Offset="0" />
-                    <GradientStop Color="#61ff8400"
-                                  Offset="1" />
-                </LinearGradientBrush>
-            </Setter.Value>
-        </Setter>
+        <Setter Property="Background"
+                Value="{DynamicResource NotifyBalloonBackground}" />
         <Style.Triggers>
             <DataTrigger Binding="{Binding Path=Balloon, RelativeSource={RelativeSource AncestorType=UserControl}}"
                          Value="{x:Null}">
@@ -3961,16 +3960,20 @@
     </Style>
     <Style x:Key="NotifyIconBalloonCloseButton"
            TargetType="Button">
+        <Setter Property="Effect"
+                Value="{DynamicResource ResourceKey=MenuHeaderShadow}" />
         <Setter Property="OverridesDefaultStyle"
             Value="true" />
         <Setter Property="FontFamily"
                 Value="Webdings" />
+        <Setter Property="FontSize"
+                Value="12" />
         <Setter Property="Foreground"
-                Value="{DynamicResource MenuItemForeground}" />
+                Value="{DynamicResource MenuHeaderForeground}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
-                    <ContentPresenter Margin="0,-2,0,0"
+                    <ContentPresenter Margin="0,0,0,3"
                                       HorizontalAlignment="Center"
                                       VerticalAlignment="Center" />
                 </ControlTemplate>
@@ -4003,12 +4006,16 @@
     </Style>
     <Style x:Key="NotifyIconBalloonTitle"
            TargetType="TextBlock">
+        <Setter Property="Effect"
+                Value="{DynamicResource ResourceKey=MenuHeaderShadow}" />
         <Setter Property="Foreground"
-                Value="{DynamicResource MenuItemForeground}" />
+                Value="{DynamicResource MenuHeaderForeground}" />
+        <Setter Property="FontSize"
+                Value="{DynamicResource SmallFontSize}" />
         <Setter Property="Margin"
-                Value="0,-1,0,0" />
-        <Setter Property="MaxWidth"
-                Value="145" />
+                Value="0,-1,0,2" />
+        <Setter Property="Width"
+                Value="120" />
         <Setter Property="Padding"
                 Value="0,0,5,0" />
         <Setter Property="TextTrimming"
@@ -4022,10 +4029,10 @@
                     <BeginStoryboard>
                         <Storyboard>
                             <DoubleAnimation Storyboard.TargetProperty="Width"
-                                        From="0"
-                                        To="145"
-                                        Duration="0:0:0.2"
-                                        FillBehavior="Stop" />
+                                             From="0"
+                                             To="120"
+                                             Duration="0:0:0.2"
+                                             FillBehavior="Stop" />
                         </Storyboard>
                     </BeginStoryboard>
                 </DataTrigger.ExitActions>
@@ -4036,6 +4043,8 @@
            TargetType="TextBlock">
         <Setter Property="Foreground"
                 Value="{DynamicResource MenuItemForeground}" />
+        <Setter Property="FontSize"
+                Value="{DynamicResource MediumFontSize}" />
         <Setter Property="TextWrapping"
                 Value="Wrap" />
     </Style>
@@ -4061,6 +4070,6 @@
         <Setter Property="MaxWidth"
                 Value="260" />
         <Setter Property="Padding"
-                Value="10,5" />
+                Value="10,7" />
     </Style>
 </ResourceDictionary>

--- a/Cairo Desktop/Cairo Desktop/Themes/Cairo.xaml
+++ b/Cairo Desktop/Cairo Desktop/Themes/Cairo.xaml
@@ -3972,7 +3972,7 @@
                         <Storyboard>
                             <DoubleAnimation Storyboard.TargetProperty="Width"
                                              To="0"
-                                             Duration="0:0:0.2">
+                                             Duration="0:0:0.4">
                                 <DoubleAnimation.EasingFunction>
                                     <QuadraticEase EasingMode="EaseInOut" />
                                 </DoubleAnimation.EasingFunction>
@@ -3985,7 +3985,7 @@
                         <Storyboard>
                             <DoubleAnimation Storyboard.TargetProperty="Width"
                                              To="1"
-                                             Duration="0:0:0.2">
+                                             Duration="0:0:0.4">
                                 <DoubleAnimation.EasingFunction>
                                     <QuadraticEase EasingMode="EaseInOut" />
                                 </DoubleAnimation.EasingFunction>

--- a/Cairo Desktop/Cairo Desktop/Themes/Cairo.xaml
+++ b/Cairo Desktop/Cairo Desktop/Themes/Cairo.xaml
@@ -3913,4 +3913,154 @@
             </Setter.Value>
         </Setter>
     </Style>
+    
+    <!-- Styles for notification area and balloon notifications -->
+    <Style x:Key="NotifyIconBorder"
+           TargetType="Border">
+        <Setter Property="Background">
+            <Setter.Value>
+                <LinearGradientBrush StartPoint="0,0"
+                                     EndPoint="0,1">
+                    <GradientStop Color="#00000000"
+                                  Offset="0" />
+                    <GradientStop Color="#61ff8400"
+                                  Offset="1" />
+                </LinearGradientBrush>
+            </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Path=Balloon, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                         Value="{x:Null}">
+                <Setter Property="Background"
+                        Value="Transparent" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+    <Style x:Key="NotifyIconImage"
+           TargetType="Image">
+        <Setter Property="Margin"
+                Value="5,0,5,2" />
+        <Setter Property="Height"
+                Value="16" />
+        <Setter Property="Width"
+                Value="16" />
+    </Style>
+    <Style x:Key="NotifyIconBalloonPanel"
+           TargetType="DockPanel">
+        <Setter Property="Margin"
+                Value="0,0,5,0" />
+        <Setter Property="Visibility"
+                Value="Visible" />
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Path=Balloon, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                         Value="{x:Null}">
+                <Setter Property="Visibility"
+                        Value="Collapsed" />
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+    <Style x:Key="NotifyIconBalloonCloseButton"
+           TargetType="Button">
+        <Setter Property="OverridesDefaultStyle"
+            Value="true" />
+        <Setter Property="FontFamily"
+                Value="Webdings" />
+        <Setter Property="Foreground"
+                Value="{DynamicResource MenuItemForeground}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <ContentPresenter Margin="0,-2,0,0"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver"
+                     Value="True">
+                <Setter Property="Effect">
+                    <Setter.Value>
+                        <DropShadowEffect Color="White"
+                                          ShadowDepth="0"
+                                          Opacity="0.5"
+                                          BlurRadius="7" />
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
+            <Trigger Property="IsPressed"
+                     Value="True">
+                <Setter Property="Effect">
+                    <Setter.Value>
+                        <DropShadowEffect Color="White"
+                                          ShadowDepth="0"
+                                          Opacity="1"
+                                          BlurRadius="7" />
+                    </Setter.Value>
+                </Setter>
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+    <Style x:Key="NotifyIconBalloonTitle"
+           TargetType="TextBlock">
+        <Setter Property="Foreground"
+                Value="{DynamicResource MenuItemForeground}" />
+        <Setter Property="Margin"
+                Value="0,-1,0,0" />
+        <Setter Property="MaxWidth"
+                Value="145" />
+        <Setter Property="Padding"
+                Value="0,0,5,0" />
+        <Setter Property="TextTrimming"
+                Value="CharacterEllipsis" />
+        <Setter Property="VerticalAlignment"
+                Value="Center" />
+        <Style.Triggers>
+            <DataTrigger Binding="{Binding Path=Balloon, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                         Value="{x:Null}">
+                <DataTrigger.ExitActions>
+                    <BeginStoryboard>
+                        <Storyboard>
+                            <DoubleAnimation Storyboard.TargetProperty="Width"
+                                        From="0"
+                                        To="145"
+                                        Duration="0:0:0.2"
+                                        FillBehavior="Stop" />
+                        </Storyboard>
+                    </BeginStoryboard>
+                </DataTrigger.ExitActions>
+            </DataTrigger>
+        </Style.Triggers>
+    </Style>
+    <Style x:Key="NotifyIconBalloonContent"
+           TargetType="TextBlock">
+        <Setter Property="Foreground"
+                Value="{DynamicResource MenuItemForeground}" />
+        <Setter Property="TextWrapping"
+                Value="Wrap" />
+    </Style>
+    <Style x:Key="NotifyIconBalloonContentTitle"
+           TargetType="TextBlock"
+           BasedOn="{StaticResource NotifyIconBalloonContent}">
+        <Setter Property="FontWeight"
+                Value="Bold" />
+        <Setter Property="Margin"
+                Value="0,0,0,5" />
+    </Style>
+    <Style x:Key="NotifyIconBalloonImage"
+           TargetType="Image"
+           BasedOn="{StaticResource NotifyIconImage}">
+        <Setter Property="Margin"
+                Value="0,0,5,5" />
+        <Setter Property="VerticalAlignment"
+                Value="Center" />
+    </Style>
+    <Style x:Key="NotifyIconBalloonPopupInnerBorder"
+           TargetType="Border"
+           BasedOn="{StaticResource CairoMenuInnerBorderStyle}">
+        <Setter Property="MaxWidth"
+                Value="260" />
+        <Setter Property="Padding"
+                Value="10,5" />
+    </Style>
 </ResourceDictionary>

--- a/Cairo Desktop/CairoDesktop.Localization/DisplayString.cs
+++ b/Cairo Desktop/CairoDesktop.Localization/DisplayString.cs
@@ -188,6 +188,8 @@ namespace CairoDesktop.Localization
 
         public static string sInterface_MoveUp => getString();
 
+        public static string sInterface_Dismiss => getString();
+
         public static string sAppGrabber => getString();
 
         public static string sAppGrabber_PleaseWait => getString();

--- a/Cairo Desktop/CairoDesktop.Localization/Language.cs
+++ b/Cairo Desktop/CairoDesktop.Localization/Language.cs
@@ -46,6 +46,7 @@ namespace CairoDesktop.Localization
             { "sInterface_Go", "Go" },
             { "sInterface_MoveDown", "Move down" },
             { "sInterface_MoveUp", "Move up" },
+            { "sInterface_Dismiss", "Dismiss" },
             { "sAppGrabber", "App Grabber" },
             { "sAppGrabber_PleaseWait", "Please wait while Cairo finds your apps..." },
             { "sAppGrabber_Page1Title", "Cairo has found the following applications installed on your computer." },

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/NotificationBalloonTitleConverter.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/NotificationBalloonTitleConverter.cs
@@ -1,0 +1,27 @@
+﻿using ManagedShell.WindowsTray;
+using System;
+using System.Windows.Data;
+
+namespace CairoDesktop.MenuBarExtensions
+{
+    [ValueConversion(typeof(NotificationBalloon), typeof(string))]
+    public class NotificationBalloonTitleConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (value is NotificationBalloon balloon)
+            {
+                if (balloon.Title != string.Empty) return balloon.Title.Replace('\n', ' ').Replace('\r', ' ');
+
+                return balloon.NotifyIcon.Title.Replace('\n', ' ').Replace('\r', ' ');
+            }
+
+            return "";
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return Binding.DoNothing;
+        }
+    }
+}

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/NotificationBalloonTitleConverter.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/NotificationBalloonTitleConverter.cs
@@ -9,14 +9,25 @@ namespace CairoDesktop.MenuBarExtensions
     {
         public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
         {
+            string title = string.Empty;
+
             if (value is NotificationBalloon balloon)
             {
-                if (balloon.Title != string.Empty) return balloon.Title.Replace('\n', ' ').Replace('\r', ' ');
-
-                return balloon.NotifyIcon.Title.Replace('\n', ' ').Replace('\r', ' ');
+                if (balloon.Info != string.Empty)
+                {
+                    title = balloon.Info;
+                }
+                else if (balloon.Title != string.Empty)
+                {
+                    title = balloon.Title;
+                }
+                else
+                {
+                    title = balloon.NotifyIcon.Title;
+                }
             }
 
-            return "";
+            return title.Replace('\n', ' ').Replace('\r', ' ');
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/NotificationBalloonWidthConverter.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/NotificationBalloonWidthConverter.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Windows.Data;
+
+namespace CairoDesktop.MenuBarExtensions
+{
+    [ValueConversion(typeof(double[]), typeof(double))]
+    public class NotificationBalloonWidthConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            double result = 1.0;
+
+            for (int i = 0; i < values.Length; i++)
+            {
+                if (values[i] is double item)
+                    result *= item;
+            }
+
+            return result;
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, System.Globalization.CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTray.xaml
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTray.xaml
@@ -5,7 +5,7 @@
              xmlns:local="clr-namespace:CairoDesktop.MenuBarExtensions"
              x:Class="CairoDesktop.MenuBarExtensions.SystemTray"
              x:Name="CairoSystemTray"
-             Height="22"
+             Height="23"
              Margin="8,0,8,0">
     <UserControl.Resources>
         <Style TargetType="ItemsControl">

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTray.xaml
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTray.xaml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<UserControl xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d" xmlns:l10n="clr-namespace:CairoDesktop.Localization;assembly=CairoDesktop.Localization"
+<UserControl xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:l10n="clr-namespace:CairoDesktop.Localization;assembly=CairoDesktop.Localization"
+             xmlns:local="clr-namespace:CairoDesktop.MenuBarExtensions"
              x:Class="CairoDesktop.MenuBarExtensions.SystemTray"
              x:Name="CairoSystemTray"
              Height="22"
@@ -24,19 +27,7 @@
             <Setter Property="ItemTemplate">
                 <Setter.Value>
                     <DataTemplate>
-                        <Border MouseUp="Image_MouseUp" 
-                                MouseDown="Image_MouseDown" 
-                                MouseEnter="Image_MouseEnter" 
-                                MouseLeave="Image_MouseLeave" 
-                                MouseMove="Image_MouseMove" 
-                                Background="Transparent" 
-                                ToolTip="{Binding Path=Title}" 
-                                ToolTipService.Placement="Bottom">
-                            <Image Source="{Binding Path=Icon, Mode=OneWay}"
-                                   Width="16"
-                                   Height="16"
-                                   Margin="5,0,5,2" />
-                        </Border>
+                        <local:SystemTrayIcon Host="{Binding RelativeSource={RelativeSource AncestorType=UserControl}}" />
                     </DataTemplate>
                 </Setter.Value>
             </Setter>

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTray.xaml
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTray.xaml
@@ -6,7 +6,9 @@
              x:Class="CairoDesktop.MenuBarExtensions.SystemTray"
              x:Name="CairoSystemTray"
              Height="23"
-             Margin="8,0,8,0">
+             Margin="8,0,8,0"
+             Loaded="CairoSystemTray_Loaded"
+             Unloaded="CairoSystemTray_Unloaded">
     <UserControl.Resources>
         <Style TargetType="ItemsControl">
             <Setter Property="Template">
@@ -36,6 +38,7 @@
     <StackPanel Orientation="Horizontal">
         <ItemsControl ItemsSource="{Binding Path=UnpinnedIcons}" Name="UnpinnedItems" Visibility="Collapsed" />
         <ToggleButton Name="btnToggle" Click="btnToggle_Click" Visibility="Collapsed" ToolTip="{Binding Path=(l10n:DisplayString.sMenuBar_ToggleNotificationArea)}" ToolTipService.Placement="Bottom" Style="{StaticResource CairoSystrayExpanderStyle}" />
+        <ItemsControl ItemsSource="{Binding Path=PromotedIcons, ElementName=CairoSystemTray}" Name="PromotedItems" />
         <ItemsControl ItemsSource="{Binding Path=PinnedIcons}" Name="PinnedItems" />
     </StackPanel>
 </UserControl>

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTray.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTray.xaml.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Input;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using CairoDesktop.Application.Interfaces;
@@ -40,6 +38,15 @@ namespace CairoDesktop.MenuBarExtensions
             if (Settings.Instance.EnableSysTray && (Settings.Instance.EnableTaskbar || EnvironmentHelper.IsAppRunningAsShell) && _notificationArea.Handle == IntPtr.Zero)
             {
                 _notificationArea.Initialize();
+            }
+        }
+
+        public void SetTrayHostSizeData()
+        {
+            if (Host != null)
+            {
+                // set current menu bar to return placement for ABM_GETTASKBARPOS message
+                _notificationArea.SetTrayHostSizeData(GetTrayHostSizeData());
             }
         }
 
@@ -98,56 +105,6 @@ namespace CairoDesktop.MenuBarExtensions
                     Right = (int)((dimensions.Left + dimensions.Width) * dimensions.DpiScale)
                 }
             };
-        }
-
-        private void Image_MouseDown(object sender, MouseButtonEventArgs e)
-        {
-            var trayIcon = (sender as Decorator).DataContext as NotifyIcon;
-
-            if (Host != null)
-            {
-                // set current menu bar to return placement for ABM_GETTASKBARPOS message
-                _notificationArea.SetTrayHostSizeData(GetTrayHostSizeData());
-            }
-
-            trayIcon?.IconMouseDown(e.ChangedButton, MouseHelper.GetCursorPositionParam(), System.Windows.Forms.SystemInformation.DoubleClickTime);
-        }
-
-        private void Image_MouseUp(object sender, MouseButtonEventArgs e)
-        {
-            var trayIcon = (sender as Decorator).DataContext as NotifyIcon;
-
-            trayIcon?.IconMouseUp(e.ChangedButton, MouseHelper.GetCursorPositionParam(), System.Windows.Forms.SystemInformation.DoubleClickTime);
-        }
-
-        private void Image_MouseEnter(object sender, MouseEventArgs e)
-        {
-            Decorator sendingDecorator = sender as Decorator;
-            var trayIcon = sendingDecorator.DataContext as NotifyIcon;
-
-            if (trayIcon != null)
-            {
-                // update icon position for Shell_NotifyIconGetRect
-                Point location = sendingDecorator.PointToScreen(new Point(0, 0));
-                double dpiScale = PresentationSource.FromVisual(this).CompositionTarget.TransformToDevice.M11;
-
-                trayIcon.Placement = new NativeMethods.Rect { Top = (int)location.Y, Left = (int)location.X, Bottom = (int)(sendingDecorator.ActualHeight * dpiScale), Right = (int)(sendingDecorator.ActualWidth * dpiScale) };
-                trayIcon.IconMouseEnter(MouseHelper.GetCursorPositionParam());
-            }
-        }
-
-        private void Image_MouseLeave(object sender, MouseEventArgs e)
-        {
-            var trayIcon = (sender as Decorator).DataContext as NotifyIcon;
-
-            trayIcon?.IconMouseLeave(MouseHelper.GetCursorPositionParam());
-        }
-
-        private void Image_MouseMove(object sender, MouseEventArgs e)
-        {
-            var trayIcon = (sender as Decorator).DataContext as NotifyIcon;
-
-            trayIcon?.IconMouseMove(MouseHelper.GetCursorPositionParam());
         }
 
         private void Settings_PropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTray.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTray.xaml.cs
@@ -33,7 +33,7 @@ namespace CairoDesktop.MenuBarExtensions
             {
                 UnpinnedItems.Visibility = Visibility.Visible;
             }
-
+            // TODO: Promote icons with balloons to the pinned area when tray is collapsed
             // Don't allow showing both the Windows TaskBar and the Cairo tray
             if (Settings.Instance.EnableSysTray && (Settings.Instance.EnableTaskbar || EnvironmentHelper.IsAppRunningAsShell) && _notificationArea.Handle == IntPtr.Zero)
             {

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTray.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTray.xaml.cs
@@ -96,20 +96,9 @@ namespace CairoDesktop.MenuBarExtensions
 
             PromotedIcons.Add(notifyIcon);
 
-            // valid timeout is 12-30 seconds
-            int timeout = e.Balloon.Timeout;
-            if (timeout < 12000)
-            {
-                timeout = 12000;
-            }
-            else if (timeout > 30000)
-            {
-                timeout = 30000;
-            }
-
             DispatcherTimer unpromoteTimer = new DispatcherTimer
             {
-                Interval = TimeSpan.FromMilliseconds(timeout + 600) // Keep it around a few ms for the animation to complete
+                Interval = TimeSpan.FromMilliseconds(SystemTrayIcon.GetAdjustedBalloonTimeout(e.Balloon) + 400) // Keep it around a few ms for the animation to complete
             };
             unpromoteTimer.Tick += (object timerSender, EventArgs timerE) =>
             {

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTray.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTray.xaml.cs
@@ -32,6 +32,9 @@ namespace CairoDesktop.MenuBarExtensions
             DataContext = _notificationArea;
             Host = host;
 
+            ((INotifyCollectionChanged)PinnedItems.Items).CollectionChanged += PinnedItems_CollectionChanged;
+            ((INotifyCollectionChanged)UnpinnedItems.Items).CollectionChanged += UnpinnedItems_CollectionChanged;
+
             if (Settings.Instance.SysTrayAlwaysExpanded)
             {
                 PromotedItems.Visibility = Visibility.Collapsed;
@@ -194,9 +197,6 @@ namespace CairoDesktop.MenuBarExtensions
             }
 
             Settings.Instance.PropertyChanged += Settings_PropertyChanged;
-
-            ((INotifyCollectionChanged)PinnedItems.Items).CollectionChanged += PinnedItems_CollectionChanged;
-            ((INotifyCollectionChanged)UnpinnedItems.Items).CollectionChanged += UnpinnedItems_CollectionChanged;
             _notificationArea.NotificationBalloonShown += NotificationArea_NotificationBalloonShown;
 
             _isLoaded = true;
@@ -210,9 +210,6 @@ namespace CairoDesktop.MenuBarExtensions
             }
 
             Settings.Instance.PropertyChanged -= Settings_PropertyChanged;
-
-            ((INotifyCollectionChanged)PinnedItems.Items).CollectionChanged -= PinnedItems_CollectionChanged;
-            ((INotifyCollectionChanged)UnpinnedItems.Items).CollectionChanged -= UnpinnedItems_CollectionChanged;
             _notificationArea.NotificationBalloonShown -= NotificationArea_NotificationBalloonShown;
 
             _isLoaded = false;

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTrayIcon.xaml
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTrayIcon.xaml
@@ -8,51 +8,70 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <local:NotificationBalloonTitleConverter x:Key="balloonTitleConverter" />
+            <local:NotificationBalloonWidthConverter x:Key="balloonWidthConverter" />
         </ResourceDictionary>
     </UserControl.Resources>
-    <Border Style="{DynamicResource NotifyIconBorder}">
-        <StackPanel Orientation="Horizontal">
-            <Border MouseUp="Image_MouseUp" 
-                    MouseDown="Image_MouseDown" 
-                    MouseEnter="Image_MouseEnter" 
-                    MouseLeave="Image_MouseLeave" 
-                    MouseMove="Image_MouseMove" 
-                    Background="Transparent" 
-                    ToolTip="{Binding Path=Title}" 
-                    ToolTipService.Placement="Bottom">
-                <Image Source="{Binding Path=Icon, Mode=OneWay}"
-                       Style="{DynamicResource NotifyIconImage}" />
+    <StackPanel Style="{DynamicResource NotifyIconPanel}">
+        <Border MouseUp="Image_MouseUp" 
+                MouseDown="Image_MouseDown" 
+                MouseEnter="Image_MouseEnter" 
+                MouseLeave="Image_MouseLeave" 
+                MouseMove="Image_MouseMove" 
+                Background="Transparent" 
+                ToolTip="{Binding Path=Title}" 
+                ToolTipService.Placement="Bottom">
+            <Image Source="{Binding Path=Icon, Mode=OneWay}"
+                   Style="{DynamicResource NotifyIconImage}" />
+        </Border>
+        <!-- The width of this border animates to a constant value 0..1 via its style -->
+        <Border Width="0"
+                Style="{DynamicResource NotifyIconBalloonAnimatedBorder}"
+                x:Name="AnimatingBorder" />
+        <!-- This border contains the actual notification, its width is calculated by
+             multiplying the width of the child StackPanel by the width of the above border -->
+        <Border>
+            <!-- The second border here shows/hides based on the balloon's existence.
+                 We also use this element's hover state to determine if the popup should
+                 show, as it will hide during the dismiss animation. This prevents showing
+                 an empty popup. -->
+            <Border Style="{DynamicResource NotifyIconBalloonInlineBorder}"
+                    x:Name="BalloonInlineBorder">
+                <StackPanel Style="{DynamicResource NotifyIconBalloonInlinePanel}"
+                             x:Name="BalloonInlinePanel">
+                     <TextBlock Text="{Binding Path=Balloon, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource balloonTitleConverter}}"
+                                Style="{DynamicResource NotifyIconBalloonInlineTitle}"
+                                MouseLeftButtonUp="TextBlock_MouseLeftButtonUp" />
+                    <Button Style="{DynamicResource NotifyIconBalloonInlineCloseButton}"
+                            ToolTip="{Binding Path=(l10n:DisplayString.sInterface_Dismiss)}"
+                            Click="Button_Click">r</Button>
+                </StackPanel>
             </Border>
-            <DockPanel Style="{DynamicResource NotifyIconBalloonPanel}"
-                       Name="BalloonPanel">
-                <Button Style="{DynamicResource NotifyIconBalloonCloseButton}"
-                        ToolTip="{Binding Path=(l10n:DisplayString.sInterface_Dismiss)}"
-                        DockPanel.Dock="Right"
-                        Click="Button_Click">r</Button>
-                <TextBlock Text="{Binding Path=Balloon, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource balloonTitleConverter}}"
-                           Style="{DynamicResource NotifyIconBalloonTitle}"
-                           MouseLeftButtonUp="TextBlock_MouseLeftButtonUp" />
-            </DockPanel>
-            <Popup AllowsTransparency="True"
-                   PopupAnimation="Slide"
-                   Name="BalloonPopup"
-                   IsOpen="{Binding ElementName=BalloonPanel, Path=IsMouseOver, Mode=OneWay}">
-                <Border Style="{StaticResource ResourceKey=CairoMenuBorderStyle}">
-                    <Border Style="{StaticResource ResourceKey=NotifyIconBalloonPopupInnerBorder}">
-                        <StackPanel Orientation="Vertical">
-                            <DockPanel>
-                                <Image Source="{Binding Path=Balloon.Icon, RelativeSource={RelativeSource AncestorType=UserControl}, Mode=OneWay}"
-                                       Style="{DynamicResource NotifyIconBalloonImage}"
-                                       DockPanel.Dock="Left" />
-                                <TextBlock Text="{Binding Path=Balloon.Title, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                       Style="{DynamicResource NotifyIconBalloonContentTitle}" />
-                            </DockPanel>
-                            <TextBlock Text="{Binding Path=Balloon.Info, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                       Style="{DynamicResource NotifyIconBalloonContent}" />
-                        </StackPanel>
-                    </Border>
+            <Border.Width>
+                <MultiBinding Converter="{StaticResource balloonWidthConverter}">
+                    <Binding Path="ActualWidth" ElementName="BalloonInlinePanel" />
+                    <Binding Path="Width" ElementName="AnimatingBorder" />
+                </MultiBinding>
+            </Border.Width>
+        </Border>
+        <Popup AllowsTransparency="True"
+                PopupAnimation="Slide"
+                Name="BalloonPopup"
+                IsOpen="{Binding ElementName=BalloonInlineBorder, Path=IsMouseOver, Mode=OneWay}">
+            <Border Style="{StaticResource ResourceKey=CairoMenuBorderStyle}">
+                <Border Style="{StaticResource ResourceKey=NotifyIconBalloonPopupInnerBorder}">
+                    <StackPanel Orientation="Vertical">
+                        <DockPanel>
+                            <Image Source="{Binding Path=Balloon.Icon, RelativeSource={RelativeSource AncestorType=UserControl}, Mode=OneWay}"
+                                    Style="{DynamicResource NotifyIconBalloonImage}"
+                                    DockPanel.Dock="Left" />
+                            <TextBlock Text="{Binding Path=Balloon.Title, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                    Style="{DynamicResource NotifyIconBalloonTitle}" />
+                        </DockPanel>
+                        <TextBlock Text="{Binding Path=Balloon.Info, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                    Style="{DynamicResource NotifyIconBalloonContent}" />
+                    </StackPanel>
                 </Border>
-            </Popup>
-        </StackPanel>
-    </Border>
+            </Border>
+        </Popup>
+    </StackPanel>
 </UserControl>

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTrayIcon.xaml
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTrayIcon.xaml
@@ -1,0 +1,58 @@
+﻿<UserControl x:Class="CairoDesktop.MenuBarExtensions.SystemTrayIcon"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:l10n="clr-namespace:CairoDesktop.Localization;assembly=CairoDesktop.Localization"
+             xmlns:local="clr-namespace:CairoDesktop.MenuBarExtensions"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             Loaded="UserControl_Loaded"
+             Unloaded="UserControl_Unloaded">
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <local:NotificationBalloonTitleConverter x:Key="balloonTitleConverter" />
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <Border Style="{DynamicResource NotifyIconBorder}">
+        <StackPanel Orientation="Horizontal">
+            <Border MouseUp="Image_MouseUp" 
+                    MouseDown="Image_MouseDown" 
+                    MouseEnter="Image_MouseEnter" 
+                    MouseLeave="Image_MouseLeave" 
+                    MouseMove="Image_MouseMove" 
+                    Background="Transparent" 
+                    ToolTip="{Binding Path=Title}" 
+                    ToolTipService.Placement="Bottom">
+                <Image Source="{Binding Path=Icon, Mode=OneWay}"
+                       Style="{DynamicResource NotifyIconImage}" />
+            </Border>
+            <DockPanel Style="{DynamicResource NotifyIconBalloonPanel}"
+                       Name="BalloonPanel">
+                <Button Style="{DynamicResource NotifyIconBalloonCloseButton}"
+                        ToolTip="{Binding Path=(l10n:DisplayString.sInterface_Dismiss)}"
+                        DockPanel.Dock="Right"
+                        Click="Button_Click">r</Button>
+                <TextBlock Text="{Binding Path=Balloon, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource balloonTitleConverter}}"
+                           Style="{DynamicResource NotifyIconBalloonTitle}"
+                           MouseLeftButtonUp="TextBlock_MouseLeftButtonUp" />
+            </DockPanel>
+            <Popup AllowsTransparency="True"
+                   PopupAnimation="Slide"
+                   Name="BalloonPopup"
+                   IsOpen="{Binding ElementName=BalloonPanel, Path=IsMouseOver, Mode=OneWay}">
+                <Border Style="{StaticResource ResourceKey=CairoMenuBorderStyle}">
+                    <Border Style="{StaticResource ResourceKey=NotifyIconBalloonPopupInnerBorder}">
+                        <StackPanel Orientation="Vertical">
+                            <DockPanel>
+                                <Image Source="{Binding Path=Balloon.Icon, RelativeSource={RelativeSource AncestorType=UserControl}, Mode=OneWay}"
+                                       Style="{DynamicResource NotifyIconBalloonImage}"
+                                       DockPanel.Dock="Left" />
+                                <TextBlock Text="{Binding Path=Balloon.Title, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                       Style="{DynamicResource NotifyIconBalloonContentTitle}" />
+                            </DockPanel>
+                            <TextBlock Text="{Binding Path=Balloon.Info, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                       Style="{DynamicResource NotifyIconBalloonContent}" />
+                        </StackPanel>
+                    </Border>
+                </Border>
+            </Popup>
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTrayIcon.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTrayIcon.xaml.cs
@@ -131,6 +131,11 @@ namespace CairoDesktop.MenuBarExtensions
         #region Notify icon balloon notifications
         private void TrayIcon_NotificationBalloonShown(object sender, NotificationBalloonEventArgs e)
         {
+            if (Host != null && Host.Host != null && !Host.Host.GetIsPrimaryDisplay())
+            {
+                return;
+            }
+
             showBalloon(e.Balloon);
             e.Handled = true;
         }

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTrayIcon.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTrayIcon.xaml.cs
@@ -1,0 +1,186 @@
+﻿using ManagedShell.Common.Helpers;
+using ManagedShell.Interop;
+using ManagedShell.WindowsTray;
+using System;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Threading;
+
+namespace CairoDesktop.MenuBarExtensions
+{
+    /// <summary>
+    /// Interaction logic for SystemTrayIcon.xaml
+    /// </summary>
+    public partial class SystemTrayIcon : UserControl
+    {
+        public static DependencyProperty BalloonProperty = DependencyProperty.Register("Balloon", typeof(NotificationBalloon), typeof(SystemTrayIcon));
+        public static DependencyProperty HostProperty = DependencyProperty.Register("Host", typeof(SystemTray), typeof(SystemTrayIcon));
+
+        public NotificationBalloon Balloon
+        {
+            get { return (NotificationBalloon)GetValue(BalloonProperty); }
+            set { SetValue(BalloonProperty, value); }
+        }
+
+        public SystemTray Host
+        {
+            get { return (SystemTray)GetValue(HostProperty); }
+            set { SetValue(HostProperty, value); }
+        }
+
+        private DispatcherTimer _balloonTimer;
+        private bool _isLoaded;
+        private NotifyIcon _notifyIcon;
+
+        public SystemTrayIcon()
+        {
+            InitializeComponent();
+        }
+
+        private void Image_MouseDown(object sender, MouseButtonEventArgs e)
+        {
+            var trayIcon = (sender as Decorator).DataContext as NotifyIcon;
+
+            // set current menu bar to return placement for ABM_GETTASKBARPOS message
+            Host?.SetTrayHostSizeData();
+
+            trayIcon?.IconMouseDown(e.ChangedButton, MouseHelper.GetCursorPositionParam(), System.Windows.Forms.SystemInformation.DoubleClickTime);
+        }
+
+        private void Image_MouseUp(object sender, MouseButtonEventArgs e)
+        {
+            var trayIcon = (sender as Decorator).DataContext as NotifyIcon;
+
+            trayIcon?.IconMouseUp(e.ChangedButton, MouseHelper.GetCursorPositionParam(), System.Windows.Forms.SystemInformation.DoubleClickTime);
+        }
+
+        private void Image_MouseEnter(object sender, MouseEventArgs e)
+        {
+            Decorator sendingDecorator = sender as Decorator;
+            var trayIcon = sendingDecorator.DataContext as NotifyIcon;
+
+            if (trayIcon != null)
+            {
+                // update icon position for Shell_NotifyIconGetRect
+                Point location = sendingDecorator.PointToScreen(new Point(0, 0));
+                double dpiScale = PresentationSource.FromVisual(this).CompositionTarget.TransformToDevice.M11;
+
+                trayIcon.Placement = new NativeMethods.Rect { Top = (int)location.Y, Left = (int)location.X, Bottom = (int)(sendingDecorator.ActualHeight * dpiScale), Right = (int)(sendingDecorator.ActualWidth * dpiScale) };
+                trayIcon.IconMouseEnter(MouseHelper.GetCursorPositionParam());
+            }
+        }
+
+        private void Image_MouseLeave(object sender, MouseEventArgs e)
+        {
+            var trayIcon = (sender as Decorator).DataContext as NotifyIcon;
+
+            trayIcon?.IconMouseLeave(MouseHelper.GetCursorPositionParam());
+        }
+
+        private void Image_MouseMove(object sender, MouseEventArgs e)
+        {
+            var trayIcon = (sender as Decorator).DataContext as NotifyIcon;
+
+            trayIcon?.IconMouseMove(MouseHelper.GetCursorPositionParam());
+        }
+
+        private void UserControl_Loaded(object sender, RoutedEventArgs e)
+        {
+            if (_isLoaded)
+            {
+                return;
+            }
+
+            _notifyIcon = DataContext as NotifyIcon;
+
+            if (_notifyIcon == null)
+            {
+                return;
+            }
+
+            _notifyIcon.NotificationBalloonShown += TrayIcon_NotificationBalloonShown;
+
+            // If a notification was received before we started listening, it will be here. Show the first one that is not expired.
+            NotificationBalloon firstUnexpiredNotification = _notifyIcon.MissedNotifications.FirstOrDefault(balloon => balloon.Received.AddMilliseconds(balloon.Timeout) > DateTime.Now);
+
+            if (firstUnexpiredNotification != null)
+            {
+                showBalloon(firstUnexpiredNotification);
+                _notifyIcon.MissedNotifications.Remove(firstUnexpiredNotification);
+            }
+
+            _isLoaded = true;
+        }
+
+        private void UserControl_Unloaded(object sender, RoutedEventArgs e)
+        {
+            if (_notifyIcon != null)
+            {
+                _notifyIcon.NotificationBalloonShown -= TrayIcon_NotificationBalloonShown;
+            }
+
+            _isLoaded = false;
+        }
+
+        private void TrayIcon_NotificationBalloonShown(object sender, NotificationBalloonEventArgs e)
+        {
+            showBalloon(e.Balloon);
+            e.Handled = true;
+        }
+
+        private void showBalloon(NotificationBalloon balloon)
+        {
+            Balloon = balloon;
+            playSound(Balloon);
+
+            _balloonTimer?.Stop();
+
+            _balloonTimer = new DispatcherTimer
+            {
+                Interval = TimeSpan.FromMilliseconds(Balloon.Timeout)
+            };
+
+            _balloonTimer.Tick += BalloonTimer_Tick;
+            _balloonTimer.Start();
+        }
+
+        private void closeBalloon()
+        {
+            _balloonTimer?.Stop();
+            Balloon = null;
+        }
+
+        private void playSound(NotificationBalloon balloonInfo)
+        {
+            if ((balloonInfo.Flags & NativeMethods.NIIF.NOSOUND) != 0)
+            {
+                return;
+            }
+
+            SoundHelper.PlayNotificationSound();
+        }
+
+        private void BalloonTimer_Tick(object sender, EventArgs e)
+        {
+            closeBalloon();
+            Balloon?.SetVisibility(BalloonVisibility.TimedOut);
+        }
+
+        private void Button_Click(object sender, RoutedEventArgs e)
+        {
+            closeBalloon();
+            Balloon?.SetVisibility(BalloonVisibility.Hidden);
+            e.Handled = true;
+        }
+
+        private void TextBlock_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            Balloon?.Click();
+
+            closeBalloon();
+            e.Handled = true;
+        }
+    }
+}

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTrayIcon.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTrayIcon.xaml.cs
@@ -178,8 +178,6 @@ namespace CairoDesktop.MenuBarExtensions
         private void TextBlock_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
         {
             Balloon?.Click();
-
-            closeBalloon();
             e.Handled = true;
         }
     }


### PR DESCRIPTION
Currently, balloon notifications do not work at all while Cairo is running (#620). This adds support for those in Cairo.

This is an inline implementation of notification balloons. The idea is that notifications overlapping applications are annoying, and we're already taking up screen space, so let's use it to make things less annoying.

The balloon contents are previewed in the primary display's menu bar, next to the icon, with a dismiss button. There is an animation when the notification is shown and when hidden. Hovering the notification shows the full contents.

![Screenshot 2022-02-08 215016](https://user-images.githubusercontent.com/7373633/153118618-9153673b-b52d-4028-a466-0b7ecc9da091.png)

When the notification area is collapsed, icons with balloon notifications will be promoted to be shown next to the pinned icons.

A few ancillary changes in this PR:
- Matched taskbar animation easing to the new notification animation
- Increased height of the UserControl so that the top row of pixels detects hover
- Refactored notification area icons into their own UserControl