### PR TITLE
Fix issues when exiting Cairo

### DIFF
--- a/Cairo Desktop/Cairo Desktop/Cairo Desktop.csproj
+++ b/Cairo Desktop/Cairo Desktop/Cairo Desktop.csproj
@@ -67,7 +67,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedShell" Version="0.0.156" />
+    <PackageReference Include="ManagedShell" Version="0.0.158" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/Cairo Desktop/Cairo Desktop/Program.cs
+++ b/Cairo Desktop/Cairo Desktop/Program.cs
@@ -94,6 +94,10 @@ namespace CairoDesktop
                         options.LogsFolderPath = CairoApplication.LogsFolder;
                     });
                 })
+                .ConfigureHostOptions(options =>
+                {
+                    options.ShutdownTimeout = TimeSpan.FromSeconds(10);
+                })
                 .Build();
 
             var app = _host.Services.GetRequiredService<ICairoApplication>();

--- a/Cairo Desktop/CairoDesktop.Common/CairoDesktop.Common.csproj
+++ b/Cairo Desktop/CairoDesktop.Common/CairoDesktop.Common.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedShell" Version="0.0.156" />
+    <PackageReference Include="ManagedShell" Version="0.0.158" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
   </ItemGroup>

--- a/Installer/CairoShell.nsi
+++ b/Installer/CairoShell.nsi
@@ -115,6 +115,7 @@ Section "$(SECT_cairo)" cairo
   DetailPrint "Installing Cairo files"
   File "..\Cairo Desktop\Build\${ARCNAME}\Release\CairoDesktop.exe"
   File "..\Cairo Desktop\Build\${ARCNAME}\Release\*.dll"
+  File "..\Cairo Desktop\Build\${ARCNAME}\Release\*.config"
 
   CreateDirectory "$INSTDIR\Themes"
   File /r "..\Cairo Desktop\Build\${ARCNAME}\Release\Themes"


### PR DESCRIPTION
- Double host shutdown timeout from default 5 seconds to 10. I was hitting this timeout from time to time.
- Fix installer not laying down config file which includes binding redirects, needed for Microsoft.Extensions.Hosting dependencies (made apparent after updating these libs)
- Update ManagedShell to fix desktop icons staying hidden after exit