### PR TITLE
Remove access to updater if it isn't available

### DIFF
--- a/Cairo Desktop/Cairo Desktop/MenuBar.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/MenuBar.xaml.cs
@@ -123,6 +123,11 @@ namespace CairoDesktop
 
         private void setupCairoMenu()
         {
+            if (!_applicationUpdateService.IsAvailable)
+            {
+                OpenCheckForUpdates.Visibility = Visibility.Collapsed;
+            }
+
             // Add CairoMenu MenuItems
             if (_cairoApplication.CairoMenu.Count > 0)
             {

--- a/Cairo Desktop/Cairo Desktop/SettingsUI.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/SettingsUI.xaml.cs
@@ -471,7 +471,14 @@ namespace CairoDesktop
         #region Startup checks
         private void checkUpdateConfig()
         {
-            chkEnableAutoUpdates.IsChecked = _applicationUpdateService.AutomaticUpdatesEnabled;
+            if (_applicationUpdateService.IsAvailable)
+            {
+                chkEnableAutoUpdates.IsChecked = _applicationUpdateService.AutomaticUpdatesEnabled;
+            }
+            else
+            {
+                chkEnableAutoUpdates.Visibility = Visibility.Collapsed;
+            }
         }
 
         private void checkTrayStatus()

--- a/Cairo Desktop/CairoDesktop.Application/Interfaces/IApplicationUpdateService.cs
+++ b/Cairo Desktop/CairoDesktop.Application/Interfaces/IApplicationUpdateService.cs
@@ -6,6 +6,8 @@ namespace CairoDesktop.Application.Interfaces
     {
         bool AutomaticUpdatesEnabled { get; set; }
 
+        bool IsAvailable { get; }
+
         void CheckForUpdates();
     }
 }

--- a/Cairo Desktop/CairoDesktop.Infrastructure/Services/WinSparkleUpdateService.cs
+++ b/Cairo Desktop/CairoDesktop.Infrastructure/Services/WinSparkleUpdateService.cs
@@ -15,11 +15,14 @@ namespace CairoDesktop.Infrastructure.Services
         private readonly ILogger<WinSparkleApplicationUpdateService> _logger;
         private readonly ICairoApplication _app;
 
+        private bool _isInitialized;
+
         private WinSparkle.win_sparkle_can_shutdown_callback_t _canShutdownDelegate;
         private WinSparkle.win_sparkle_shutdown_request_callback_t _shutdownDelegate;
 
         public WinSparkleApplicationUpdateService(ILogger<WinSparkleApplicationUpdateService> logger, ICairoApplication app)
         {
+            _isInitialized = false;
             _logger = logger;
             _app = app;
 
@@ -34,6 +37,8 @@ namespace CairoDesktop.Infrastructure.Services
                 WinSparkle.win_sparkle_set_can_shutdown_callback(_canShutdownDelegate);
                 WinSparkle.win_sparkle_set_shutdown_request_callback(_shutdownDelegate);
                 WinSparkle.win_sparkle_init();
+
+                _isInitialized = true;
             }
             catch (Exception e)
             {
@@ -73,6 +78,8 @@ namespace CairoDesktop.Infrastructure.Services
             }
         }
 
+        public bool IsAvailable => _isInitialized;
+
         public void CheckForUpdates()
         {
             try
@@ -100,6 +107,7 @@ namespace CairoDesktop.Infrastructure.Services
             try
             {
                 WinSparkle.win_sparkle_cleanup();
+                _isInitialized = false;
             }
             catch (Exception e)
             {


### PR DESCRIPTION
If you delete WinSparkle.dll, the updater options should go away.