### PR TITLE
Hide recursive Desktop icon on Windows 11 insider

### DIFF
--- a/Cairo Desktop/CairoDesktop.Common/FolderView.cs
+++ b/Cairo Desktop/CairoDesktop.Common/FolderView.cs
@@ -65,6 +65,12 @@ namespace CairoDesktop.Common
                     {
                         return false;
                     }
+
+                    // in newer Windows 11 builds, the Desktop also lists itself
+                    if (file.Path == path)
+                    {
+                        return false;
+                    }
                 }
 
                 if (file.Path == @"::{21EC2020-3AEA-1069-A2DD-08002B30309D}\::{98F2AB62-0E29-4E4C-8EE7-B542E66740B1}")


### PR DESCRIPTION
In newer versions of Windows 11, the Desktop shell folder also enumerates the user folders that used to be displayed in This PC. One of these is Desktop, which is simply recursive, so we should hide it (along with the others, which our existing logic already handles well).