### PR TITLE
Allow placing Taskbar and MenuBar on secondary monitor

### DIFF
--- a/Cairo Desktop/Cairo Desktop/MenuBar.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/MenuBar.xaml.cs
@@ -185,7 +185,7 @@ namespace CairoDesktop
             registerCairoMenuHotKey();
 
             // Register L+R Windows key to open Programs menu
-            if (EnvironmentHelper.IsAppRunningAsShell && Screen.Primary && programsMenuHotKeys.Count < 1)
+            if (EnvironmentHelper.IsAppRunningAsShell && Screen.Matches(Settings.Instance.MenuBarMonitor) && programsMenuHotKeys.Count < 1)
             {
                 /*if (keyboardListener == null)
                     keyboardListener = new LowLevelKeyboardListener();
@@ -197,7 +197,7 @@ namespace CairoDesktop
                 programsMenuHotKeys.Add(new HotKey(Key.RWin, HotKeyModifier.Win | HotKeyModifier.NoRepeat, OnShowProgramsMenu));
                 programsMenuHotKeys.Add(new HotKey(Key.Escape, HotKeyModifier.Ctrl | HotKeyModifier.NoRepeat, OnShowProgramsMenu));
             }
-            else if (EnvironmentHelper.IsAppRunningAsShell && Screen.Primary)
+            else if (EnvironmentHelper.IsAppRunningAsShell && Screen.Matches(Settings.Instance.MenuBarMonitor))
             {
                 foreach (var hotkey in programsMenuHotKeys)
                 {
@@ -212,11 +212,11 @@ namespace CairoDesktop
 
         private void registerCairoMenuHotKey()
         {
-            if (Settings.Instance.EnableCairoMenuHotKey && Screen.Primary && cairoMenuHotKey == null)
+            if (Settings.Instance.EnableCairoMenuHotKey && Screen.Matches(Settings.Instance.MenuBarMonitor) && cairoMenuHotKey == null)
             {
                 cairoMenuHotKey = HotKeyManager.RegisterHotKey(Settings.Instance.CairoMenuHotKey, OnShowCairoMenu);
             }
-            else if (Settings.Instance.EnableCairoMenuHotKey && Screen.Primary)
+            else if (Settings.Instance.EnableCairoMenuHotKey && Screen.Matches(Settings.Instance.MenuBarMonitor))
             {
                 cairoMenuHotKey.Action = OnShowCairoMenu;
             }
@@ -224,7 +224,7 @@ namespace CairoDesktop
 
         private void unregisterCairoMenuHotKey()
         {
-            if (Screen.Primary)
+            if (Screen.Matches(Settings.Instance.MenuBarMonitor))
             {
                 cairoMenuHotKey?.Dispose();
                 cairoMenuHotKey = null;
@@ -402,7 +402,7 @@ namespace CairoDesktop
             {
                 switch (e.PropertyName)
                 {
-                    case "EnableCairoMenuHotKey" when Screen.Primary:
+                    case "EnableCairoMenuHotKey" when Screen.Matches(Settings.Instance.MenuBarMonitor):
                         if (Settings.Instance.EnableCairoMenuHotKey)
                         {
                             registerCairoMenuHotKey();
@@ -413,7 +413,7 @@ namespace CairoDesktop
                         }
 
                         break;
-                    case "CairoMenuHotKey" when Screen.Primary:
+                    case "CairoMenuHotKey" when Screen.Matches(Settings.Instance.MenuBarMonitor):
                         if (Settings.Instance.EnableCairoMenuHotKey)
                         {
                             unregisterCairoMenuHotKey();
@@ -595,9 +595,9 @@ namespace CairoDesktop
             return Handle;
         }
 
-        public bool GetIsPrimaryDisplay()
+        public bool GetIsMainMenuBar()
         {
-            return Screen.Primary;
+            return Screen.Matches(Settings.Instance.MenuBarMonitor);
         }
 
         public MenuBarDimensions GetDimensions()

--- a/Cairo Desktop/Cairo Desktop/Services/AppBarWindowService.cs
+++ b/Cairo Desktop/Cairo Desktop/Services/AppBarWindowService.cs
@@ -47,9 +47,11 @@ namespace CairoDesktop.Services
             HandleSettingChange(e.PropertyName);
         }
 
+        protected abstract bool IsMainScreen(AppBarScreen screen);
+
         public void HandleScreenAdded(AppBarScreen screen)
         {
-            if (EnableService && (EnableMultiMon || screen.Primary))
+            if (EnableService && (EnableMultiMon || IsMainScreen(screen)))
             {
                 OpenWindow(screen);
             }
@@ -86,7 +88,7 @@ namespace CairoDesktop.Services
             }
             else if (Windows.Count > 0)
             {
-                Windows[0].Screen = AppBarScreen.FromPrimaryScreen();
+                Windows[0].Screen = _windowManager.ScreenState.Find(IsMainScreen) ?? AppBarScreen.FromPrimaryScreen();
                 Windows[0].SetScreenPosition();
             }
         }
@@ -127,7 +129,7 @@ namespace CairoDesktop.Services
             {
                 foreach (var screen in _windowManager.ScreenState)
                 {
-                    if (screen.Primary)
+                    if (IsMainScreen(screen))
                     {
                         continue;
                     }

--- a/Cairo Desktop/Cairo Desktop/Services/MenuBarWindowService.cs
+++ b/Cairo Desktop/Cairo Desktop/Services/MenuBarWindowService.cs
@@ -43,5 +43,8 @@ namespace CairoDesktop.Services
             Windows.Add(newMenuBar);
             newMenuBar.Show();
         }
+
+        protected override bool IsMainScreen(AppBarScreen screen)
+            => screen.Matches(Settings.Instance.MenuBarMonitor);
     }
 }

--- a/Cairo Desktop/Cairo Desktop/Services/TaskbarWindowService.cs
+++ b/Cairo Desktop/Cairo Desktop/Services/TaskbarWindowService.cs
@@ -3,6 +3,8 @@ using CairoDesktop.Application.Interfaces;
 using CairoDesktop.Configuration;
 using CairoDesktop.Infrastructure.Services;
 using CairoDesktop.Interfaces;
+using CairoDesktop.SupportingClasses;
+
 using ManagedShell.AppBar;
 
 namespace CairoDesktop.Services
@@ -83,6 +85,9 @@ namespace CairoDesktop.Services
             Windows.Add(newTaskbar);
             newTaskbar.Show();
         }
+
+        protected override bool IsMainScreen(AppBarScreen screen)
+            => screen.Matches(Settings.Instance.TaskbarMonitor);
 
         public override void Dispose()
         {

--- a/Cairo Desktop/Cairo Desktop/SettingsUI.xaml
+++ b/Cairo Desktop/Cairo Desktop/SettingsUI.xaml
@@ -845,6 +845,19 @@
                     <TextBlock Text="{Binding Path=(l10n:DisplayString.sSettings_Appearance)}"
                                Style="{StaticResource SettingGroupHeader}" />
                     <StackPanel Orientation="Horizontal">
+                      <TextBlock Text="{Binding Path=(l10n:DisplayString.sSettings_General_TimeFormat)}" />
+                      <TextBox Name="primaryScreenSetting"
+                               ToolTip="{Binding Path=(l10n:DisplayString.sSettings_General_TimeFormatTooltip)}">
+                        <TextBox.Text>
+                          <Binding Path="PrimaryMonitor"
+                                                   Source="{x:Static Settings:Settings.Instance}"
+                                                   UpdateSourceTrigger="PropertyChanged">
+
+                          </Binding>
+                        </TextBox.Text>
+                      </TextBox>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal">
                         <TextBlock Text="{Binding Path=(l10n:DisplayString.sSettings_General_TimeFormat)}" />
                         <TextBox Name="timeSetting"
                                  ToolTip="{Binding Path=(l10n:DisplayString.sSettings_General_TimeFormatTooltip)}">

--- a/Cairo Desktop/Cairo Desktop/SupportingClasses/ScreenEqualityComparer.cs
+++ b/Cairo Desktop/Cairo Desktop/SupportingClasses/ScreenEqualityComparer.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+using ManagedShell.AppBar;
+
+namespace CairoDesktop.SupportingClasses
+{
+    sealed class ScreenEqualityComparer : IEqualityComparer<AppBarScreen>
+    {
+        public bool Equals(AppBarScreen x, AppBarScreen y) => x?.DeviceName == y?.DeviceName;
+        public int GetHashCode(AppBarScreen obj) => obj?.GetHashCode() ?? 42;
+
+        public static ScreenEqualityComparer Instance { get; } = new ScreenEqualityComparer();
+        ScreenEqualityComparer() { }
+    }
+}

--- a/Cairo Desktop/Cairo Desktop/SupportingClasses/ScreenPreferences.cs
+++ b/Cairo Desktop/Cairo Desktop/SupportingClasses/ScreenPreferences.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+using CairoDesktop.Configuration;
+using CairoDesktop.Interfaces;
+
+using ManagedShell.AppBar;
+
+namespace CairoDesktop.SupportingClasses
+{
+    static class ScreenPreferences
+    {
+        public static bool Matches(this AppBarScreen screen, MonitorPreference preference)
+        {
+            if (preference is MonitorFromCoordinatesPreference coordinates)
+            {
+                return screen.Bounds.Contains(coordinates.Coordinates.X, coordinates.Coordinates.Y);
+            }
+
+            if (preference is PrimaryMonitorPreference _ || preference == null)
+            {
+                return screen.Primary;
+            }
+            
+            throw new NotImplementedException(preference.GetType().FullName);
+        }
+
+        public static AppBarScreen GetScreen(this IWindowManager windowManager, MonitorPreference preference)
+            => windowManager.ScreenState.Find(s => s.Matches(preference));
+    }
+}

--- a/Cairo Desktop/Cairo Desktop/Taskbar.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/Taskbar.xaml.cs
@@ -72,7 +72,7 @@ namespace CairoDesktop
             _desktopManager = desktopManager;
             _shellManager = shellManager;
 
-            if (!Screen.Primary && !Settings.Instance.EnableMenuBarMultiMon)
+            if (!Screen.Matches(Settings.Instance.TaskbarMonitor) && !Settings.Instance.EnableMenuBarMultiMon)
             {
                 ProcessScreenChanges = true;
             }
@@ -146,7 +146,7 @@ namespace CairoDesktop
                     return true;
                 }
 
-                if (Settings.Instance.TaskbarMultiMonMode == 2 && Screen.Primary)
+                if (Settings.Instance.TaskbarMultiMonMode == 2 && Screen.Matches(Settings.Instance.TaskbarMonitor))
                 {
                     return true;
                 }
@@ -289,7 +289,7 @@ namespace CairoDesktop
         {
             // if we are showing but not reserving space, tell the desktop to adjust here
             // since we aren't changing the work area, it doesn't do this on its own
-            if (Settings.Instance.TaskbarMode == 1 && Screen.Primary)
+            if (Settings.Instance.TaskbarMode == 1 && Screen.Matches(Settings.Instance.TaskbarMonitor))
                 _desktopManager.ResetPosition(false);
         }
 

--- a/Cairo Desktop/CairoDesktop.Application/Interfaces/IMenuBar.cs
+++ b/Cairo Desktop/CairoDesktop.Application/Interfaces/IMenuBar.cs
@@ -7,7 +7,7 @@ namespace CairoDesktop.Application.Interfaces
     {
         IntPtr GetHandle();
         
-        bool GetIsPrimaryDisplay();
+        bool GetIsMainMenuBar();
 
         MenuBarDimensions GetDimensions();
     }

--- a/Cairo Desktop/CairoDesktop.Configuration/MonitorSelection.cs
+++ b/Cairo Desktop/CairoDesktop.Configuration/MonitorSelection.cs
@@ -1,0 +1,54 @@
+﻿using System.Drawing;
+using System.Globalization;
+
+namespace CairoDesktop.Configuration
+{
+    public abstract class MonitorPreference
+    {
+        protected MonitorPreference() { }
+
+        public static MonitorPreference Parse(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return null;
+
+            if (value == "Primary") return PrimaryMonitorPreference.Instance;
+
+            if (value.StartsWith("Pos=", System.StringComparison.Ordinal))
+            {
+                string[] parts = value.Split(',');
+                if (parts.Length == 2)
+                {
+                    if (TryParseInt(parts[0].Substring(4), out int x) && TryParseInt(parts[1], out int y))
+                    {
+                        return new MonitorFromCoordinatesPreference(new Point(x, y));
+                    }
+                }
+                return null;
+            }
+
+            return null;
+        }
+
+        static bool TryParseInt(string value, out int result)
+        {
+            return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out result);
+        }
+    }
+    
+    public sealed class PrimaryMonitorPreference : MonitorPreference
+    {
+        private PrimaryMonitorPreference() { }
+        internal static readonly PrimaryMonitorPreference Instance = new PrimaryMonitorPreference();
+        public override string ToString() => "Primary";
+    }
+    
+    public sealed class MonitorFromCoordinatesPreference : MonitorPreference
+    {
+        public Point Coordinates { get; set; }
+        public MonitorFromCoordinatesPreference(Point coordinates)
+        {
+            this.Coordinates = coordinates;
+        }
+        public override string ToString() => string.Format(CultureInfo.InvariantCulture, "Pos={0},{1}", Coordinates.X, Coordinates.Y);
+    }
+}

--- a/Cairo Desktop/CairoDesktop.Configuration/Properties/Settings.Designer.cs
+++ b/Cairo Desktop/CairoDesktop.Configuration/Properties/Settings.Designer.cs
@@ -647,5 +647,29 @@ namespace CairoDesktop.Configuration.Properties {
                 this["TaskbarMultiMonMode"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("Primary")]
+        public string TaskbarMonitor {
+            get {
+                return ((string)(this["TaskbarMonitor"]));
+            }
+            set {
+                this["TaskbarMonitor"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("Primary")]
+        public string MenuBarMonitor {
+            get {
+                return ((string)(this["MenuBarMonitor"]));
+            }
+            set {
+                this["MenuBarMonitor"] = value;
+            }
+        }
     }
 }

--- a/Cairo Desktop/CairoDesktop.Configuration/Properties/Settings.settings
+++ b/Cairo Desktop/CairoDesktop.Configuration/Properties/Settings.settings
@@ -158,5 +158,11 @@
     <Setting Name="TaskbarMultiMonMode" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">1</Value>
     </Setting>
+    <Setting Name="TaskbarMonitor" Type="System.String" Scope="User">
+      <Value Profile="(Default)">Primary</Value>
+    </Setting>
+    <Setting Name="MenuBarMonitor" Type="System.String" Scope="User">
+      <Value Profile="(Default)">Primary</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Cairo Desktop/CairoDesktop.Configuration/Settings.cs
+++ b/Cairo Desktop/CairoDesktop.Configuration/Settings.cs
@@ -557,6 +557,22 @@ namespace CairoDesktop.Configuration
                 }
             }
         }
+
+        public MonitorPreference TaskbarMonitor
+        {
+            get
+            {
+                return MonitorPreference.Parse(cairoSettings.TaskbarMonitor);
+            }
+            set
+            {
+                string newVal = value.ToString();
+                if (cairoSettings.TaskbarMonitor != newVal)
+                {
+                    cairoSettings.TaskbarMonitor = newVal;
+                }
+            }
+        }
         #endregion
 
         #region Menu Bar
@@ -696,6 +712,22 @@ namespace CairoDesktop.Configuration
             }
         }
 
+        public MonitorPreference MenuBarMonitor
+        {
+            get
+            {
+                return MonitorPreference.Parse(cairoSettings.MenuBarMonitor);
+            }
+            set
+            {
+                string newVal = value.ToString();
+                if (cairoSettings.MenuBarMonitor != newVal)
+                {
+                    cairoSettings.MenuBarMonitor = newVal;
+                }
+            }
+        }
+
         public bool ShowHibernate
         {
             get
@@ -804,6 +836,11 @@ namespace CairoDesktop.Configuration
         #endregion
 
         #region Advanced
+        public string PrimaryMonitor
+        {
+            get => cairoSettings.TaskbarMonitor;
+            set => cairoSettings.TaskbarMonitor = cairoSettings.MenuBarMonitor = value;
+        }
         public string TimeFormat
         {
             get

--- a/Cairo Desktop/CairoDesktop.Configuration/app.config
+++ b/Cairo Desktop/CairoDesktop.Configuration/app.config
@@ -163,6 +163,12 @@
       <setting name="TaskbarMultiMonMode" serializeAs="String">
         <value>1</value>
       </setting>
+      <setting name="TaskbarMonitor" serializeAs="String">
+        <value>Primary</value>
+      </setting>
+      <setting name="MenuBarMonitor" serializeAs="String">
+        <value>Primary</value>
+      </setting>
     </CairoDesktop.Configuration.Properties.Settings>
   </userSettings>
   <startup>

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/Clock.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/Clock.xaml.cs
@@ -19,7 +19,7 @@ namespace CairoDesktop.MenuBarExtensions
         {
             InitializeComponent();
 
-            _isPrimaryScreen = host.GetIsPrimaryDisplay();
+            _isPrimaryScreen = host.GetIsMainMenuBar();
 
             InitializeClock();
         }

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/Search.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/Search.xaml.cs
@@ -24,7 +24,7 @@ namespace CairoDesktop.MenuBarExtensions
             InitializeComponent();
 
             _cairoApplication = cairoApplication;
-            _isPrimaryScreen = host.GetIsPrimaryDisplay();
+            _isPrimaryScreen = host.GetIsMainMenuBar();
 
             SetupSearch();
         }

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTrayIcon.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTrayIcon.xaml.cs
@@ -189,7 +189,7 @@ namespace CairoDesktop.MenuBarExtensions
         #region Notify icon balloon notifications
         private void TrayIcon_NotificationBalloonShown(object sender, NotificationBalloonEventArgs e)
         {
-            if (Host != null && Host.Host != null && !Host.Host.GetIsPrimaryDisplay())
+            if (Host != null && Host.Host != null && !Host.Host.GetIsMainMenuBar())
             {
                 return;
             }


### PR DESCRIPTION
NOTE: I renamed `IMenuBar.GetIsPrimaryDisplay` to `IMenuBar.GetIsMainMenuBar` to better match semantic of the new behavior.