### PR TITLE
Add a Dependabot config to auto-update GitHub action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
This PR introduces a Dependabot config file that will make Dependabot automatically open PRs to update GitHub action versions.

For example, in `build.yml`, `actions/checkout@v2` has been out-of-date for a while and, by coincidence, `dotnet/nbgv@v0.4.0` updated to v0.4.1 within the last 24 hours. If this PR merges, Dependabot will begin submitting PRs to update these action versions, and will continue to monitor the actions for updates.

Please let me know if there's anything needed in the commit or in this PR to meet community or project standards. Thanks for your work on Cairo!