### PR TITLE
App activation

### DIFF
--- a/Cairo Desktop/Cairo Desktop/Cairo Desktop.csproj
+++ b/Cairo Desktop/Cairo Desktop/Cairo Desktop.csproj
@@ -65,7 +65,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedShell" Version="0.0.212" />
+    <PackageReference Include="ManagedShell" Version="0.0.214" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/Cairo Desktop/CairoDesktop.AppGrabber/AppGrabberService.cs
+++ b/Cairo Desktop/CairoDesktop.AppGrabber/AppGrabberService.cs
@@ -371,9 +371,21 @@ namespace CairoDesktop.AppGrabber
                     CairoMessage.Show(DisplayString.sError_FileNotFoundInfo, DisplayString.sError_OhNo, MessageBoxButton.OK, CairoMessageImage.Error);
                 }
             }
-            else if (!ShellHelper.StartProcess(app.Path, workingDirectory: getAppParentDirectory(app)))
+            else
             {
-                CairoMessage.Show(DisplayString.sError_FileNotFoundInfo, DisplayString.sError_OhNo, MessageBoxButton.OK, CairoMessageImage.Error);
+                // Store apps that are FullTrust can be activated, which works even without Explorer
+                // Non-FullTrust apps will not launch without Explorer and will hang us, so don't use activation for them
+                if (app.IsStoreApp && app.AllowRunAsAdmin)
+                {
+                    if (!ShellHelper.ActivateApplication(app.Target))
+                    {
+                        CairoMessage.Show(DisplayString.sError_FileNotFoundInfo, DisplayString.sError_OhNo, MessageBoxButton.OK, CairoMessageImage.Error);
+                    }
+                }
+                else if (!ShellHelper.StartProcess(app.Path, workingDirectory: getAppParentDirectory(app)))
+                {
+                    CairoMessage.Show(DisplayString.sError_FileNotFoundInfo, DisplayString.sError_OhNo, MessageBoxButton.OK, CairoMessageImage.Error);
+                }
             }
         }
 

--- a/Cairo Desktop/CairoDesktop.AppGrabber/ApplicationInfo.cs
+++ b/Cairo Desktop/CairoDesktop.AppGrabber/ApplicationInfo.cs
@@ -275,7 +275,7 @@ namespace CairoDesktop.AppGrabber
             ai.Path = "appx:" + storeApp.AppUserModelId;
             ai.Target = storeApp.AppUserModelId;
             ai.IconColor = storeApp.IconColor;
-            ai.AllowRunAsAdmin = storeApp.EntryPoint == "Windows.FullTrustApplication";
+            ai.AllowRunAsAdmin = storeApp.EntryPoint?.ToLower() == "windows.fulltrustapplication" || storeApp.HostId?.ToLower() == "pwa";
 
             return ai;
         }

--- a/Cairo Desktop/CairoDesktop.Common/CairoDesktop.Common.csproj
+++ b/Cairo Desktop/CairoDesktop.Common/CairoDesktop.Common.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedShell" Version="0.0.212" />
+    <PackageReference Include="ManagedShell" Version="0.0.214" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
   </ItemGroup>


### PR DESCRIPTION
Recently Windows has been packaging some inbox win32 apps such as Notepad and Paint, so we are launching them via AppUserModelId. However, the way we did this required explorer.exe to be running, even though these apps can run just fine without explorer.

This changes apps known to launch without explorer (Edge PWAs and FullTrust apps) to use the new activation method exposed by ManagedShell, so now they can launch without explorer. This doesn't change anything for sandboxed apps such as Calculator.

The reason sandboxed apps are still launched using the old method that requires explorer: Sandboxed apps still require explorer to run anyway, and app activation APIs hang for quite some time when trying to launch them, so the old method ultimately works better.

This fixes #734 which specifically mentions Edge PWAs.