### PR TITLE
Add setting for auto-hide show delay

### DIFF
--- a/Cairo Desktop/Cairo Desktop/Cairo Desktop.csproj
+++ b/Cairo Desktop/Cairo Desktop/Cairo Desktop.csproj
@@ -65,7 +65,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedShell" Version="0.0.240" />
+    <PackageReference Include="ManagedShell" Version="0.0.243" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/Cairo Desktop/Cairo Desktop/Cairo Desktop.csproj
+++ b/Cairo Desktop/Cairo Desktop/Cairo Desktop.csproj
@@ -42,14 +42,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Page Remove="Themes\FlatAccent.xaml" />
+    <Page Remove="Themes\Flat Accent.xaml" />
   </ItemGroup>
 
   <ItemGroup>
     <None Include="Themes\Fade.xaml">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </None>
-    <None Include="Themes\FlatAccent.xaml">
+    <None Include="Themes\Flat Accent.xaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Generator>MSBuild:Compile</Generator>
     </None>
@@ -65,7 +65,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedShell" Version="0.0.231" />
+    <PackageReference Include="ManagedShell" Version="0.0.240" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/Cairo Desktop/Cairo Desktop/MenuBar.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/MenuBar.xaml.cs
@@ -48,6 +48,7 @@ namespace CairoDesktop
 
             InitializeComponent();
             
+            AutoHideShowDelayMs = Settings.Instance.AutoHideShowDelayMs;
             RequiresScreenEdge = true;
 
             SetPosition();
@@ -478,6 +479,12 @@ namespace CairoDesktop
                         {
                             setupShadow();
                         }
+                        break;
+                    case "AutoHideShowDelayMs":
+                        AutoHideShowDelayMs = Settings.Instance.AutoHideShowDelayMs;
+                        break;
+                    case "CairoTheme":
+                        PeekDuringAutoHide();
                         break;
                 }
             }

--- a/Cairo Desktop/Cairo Desktop/SettingsUI.xaml
+++ b/Cairo Desktop/Cairo Desktop/SettingsUI.xaml
@@ -880,6 +880,21 @@
                             </TextBox.Text>
                         </TextBox>
                     </StackPanel>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="{Binding Path=(l10n:DisplayString.sSettings_Advanced_AutoHideShowDelayMs)}" />
+                        <TextBox Name="autoHideShowDelayMsSetting"
+                                 Width="50">
+                            <TextBox.Text>
+                                <Binding Path="AutoHideShowDelayMs"
+                                         Source="{x:Static Settings:Settings.Instance}"
+                                         UpdateSourceTrigger="PropertyChanged">
+                                    <Binding.ValidationRules>
+                                        <supportingClasses:IntegerValidationRule />
+                                    </Binding.ValidationRules>
+                                </Binding>
+                            </TextBox.Text>
+                        </TextBox>
+                    </StackPanel>
                     <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=ForceSoftwareRendering, UpdateSourceTrigger=PropertyChanged}"
                               Click="CheckBox_Click"
                               Name="chkForceSoftwareRendering">

--- a/Cairo Desktop/Cairo Desktop/SettingsUI.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/SettingsUI.xaml.cs
@@ -69,6 +69,27 @@ namespace CairoDesktop
             checkTrayStatus();
             checkRunAtLogOn();
             checkIfCanHibernate();
+
+            Settings.Instance.PropertyChanged += Settings_PropertyChanged;
+        }
+
+        private void Settings_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            switch (e.PropertyName)
+            {
+                case "DesktopLabelPosition":
+                case "DesktopIconSize":
+                case "ProgramsMenuLayout":
+                case "TaskbarMode":
+                case "TaskbarPosition":
+                case "TaskbarIconSize":
+                case "TaskbarMiddleClick":
+                case "TaskbarGroupingStyle":
+                case "TaskbarMultiMonMode":
+                case "SysTrayAlwaysExpanded":
+                    loadRadioGroups();
+                    break;
+            }
         }
 
         private void loadRadioGroups()

--- a/Cairo Desktop/Cairo Desktop/SupportingClasses/IntegerValidationRule.cs
+++ b/Cairo Desktop/Cairo Desktop/SupportingClasses/IntegerValidationRule.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Controls;
+
+namespace CairoDesktop.SupportingClasses
+{
+    public class IntegerValidationRule : ValidationRule
+    {
+        public override ValidationResult Validate(object value, CultureInfo cultureInfo)
+        {
+            try
+            {
+                if (value is string @string)
+                {
+                    if (!int.TryParse(@string, out int result))
+                    {
+                        return new ValidationResult(false, "Unrecognized value.");
+                    }
+
+                    if (result < 0)
+                    {
+                        return new ValidationResult(false, "Negative value.");
+                    }
+
+                    return new ValidationResult(true, null);
+                }
+                else
+                {
+                    return new ValidationResult(false, "Unrecognized value.");
+                }
+            }
+            catch (Exception e)
+            {
+                return new ValidationResult(false, "Error: " + e.Message);
+            }
+        }
+    }
+}

--- a/Cairo Desktop/Cairo Desktop/TaskButton.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/TaskButton.xaml.cs
@@ -103,6 +103,12 @@ namespace CairoDesktop
             }
         }
 
+        private TimeSpan getDelayInterval()
+        {
+            int autoHideDelay = Settings.Instance.TaskbarMode == 2 ? Settings.Instance.AutoHideShowDelayMs : 0;
+            return SystemParameters.MouseHoverTime.Add(TimeSpan.FromMilliseconds(autoHideDelay));
+        }
+
         #region Events
         private void UserControl_Loaded(object sender, RoutedEventArgs e)
         {
@@ -133,12 +139,13 @@ namespace CairoDesktop
                 ToolTipService.SetPlacement(btn, System.Windows.Controls.Primitives.PlacementMode.Right);
             }
 
+            TimeSpan interval = getDelayInterval();
             // drag support - delayed activation using system setting
-            dragTimer = new DispatcherTimer { Interval = SystemParameters.MouseHoverTime };
+            dragTimer = new DispatcherTimer { Interval = interval };
             dragTimer.Tick += dragTimer_Tick;
 
             // thumbnails - delayed activation using system setting
-            thumbTimer = new DispatcherTimer { Interval = SystemParameters.MouseHoverTime };
+            thumbTimer = new DispatcherTimer { Interval = interval };
             thumbTimer.Tick += thumbTimer_Tick;
         }
 
@@ -172,6 +179,11 @@ namespace CairoDesktop
                         break;
                     case "ShowTaskbarBadges":
                         setIconBadges();
+                        break;
+                    case "AutoHideShowDelayMs":
+                        TimeSpan interval = getDelayInterval();
+                        dragTimer.Interval = interval;
+                        thumbTimer.Interval = interval;
                         break;
                 }
             }

--- a/Cairo Desktop/Cairo Desktop/Taskbar.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/Taskbar.xaml.cs
@@ -404,7 +404,7 @@ namespace CairoDesktop
         #region Position and appearance
         private void setTaskbarBlur()
         {
-            if (Settings.Instance.EnableMenuBarBlur && useFullWidthAppearance && AppBarMode != AppBarMode.AutoHide)
+            if (Settings.Instance.EnableMenuBarBlur && useFullWidthAppearance)
             {
                 SetBlur(true);
             }

--- a/Cairo Desktop/Cairo Desktop/Taskbar.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/Taskbar.xaml.cs
@@ -86,6 +86,7 @@ namespace CairoDesktop
             _desktopManager = desktopManager;
             _shellManager = shellManager;
 
+            AutoHideShowDelayMs = Settings.Instance.AutoHideShowDelayMs;
             if (!Screen.Primary && !Settings.Instance.EnableMenuBarMultiMon)
             {
                 ProcessScreenChanges = true;
@@ -389,6 +390,12 @@ namespace CairoDesktop
                 case "EnableTaskbarMultiMon":
                 case "TaskbarMultiMonMode":
                     _taskbarItems?.Refresh();
+                    break;
+                case "AutoHideShowDelayMs":
+                    AutoHideShowDelayMs = Settings.Instance.AutoHideShowDelayMs;
+                    break;
+                case "CairoTheme":
+                    PeekDuringAutoHide();
                     break;
             }
         }

--- a/Cairo Desktop/Cairo Desktop/Themes/Flat Accent.xaml
+++ b/Cairo Desktop/Cairo Desktop/Themes/Flat Accent.xaml
@@ -14,9 +14,6 @@
     <SolidColorBrush Color="#BF4a4a4a" x:Key="MenuBarBorder" />
     <SolidColorBrush Color="#cF0f0f0f" x:Key="MenuBackgroundGradient" />
 
-    <!--<SolidColorBrush Color="{Binding Color, Converter={StaticResource Accent}}" x:Key="MenuItemHoverGradient" />
-    <SolidColorBrush Color="{Binding Color, Converter={StaticResource Accent}}" x:Key="MenuHeaderPressedGradient" />
-    <SolidColorBrush Color="{Binding Color, Converter={StaticResource Accent}}" x:Key="MenuTopBorderBrush" />-->
     <local:WindowsThemeColorManager FallbackColor="{StaticResource FallbackColor}" Opacity="0.5" x:Key="MenuItemHoverGradient"/>
     <local:WindowsThemeColorManager FallbackColor="{StaticResource FallbackColor}" x:Key="MenuHeaderPressedGradient"/>
     <local:WindowsThemeColorManager FallbackColor="{StaticResource FallbackColor}" x:Key="MenuTopBorderBrush"/>

--- a/Cairo Desktop/CairoDesktop.Application/Interfaces/IMenuBar.cs
+++ b/Cairo Desktop/CairoDesktop.Application/Interfaces/IMenuBar.cs
@@ -11,6 +11,6 @@ namespace CairoDesktop.Application.Interfaces
 
         MenuBarDimensions GetDimensions();
 
-        void PeekDuringAutoHide(int msToPeek = 500);
+        void PeekDuringAutoHide(int msToPeek = 1000);
     }
 }

--- a/Cairo Desktop/CairoDesktop.Common/CairoDesktop.Common.csproj
+++ b/Cairo Desktop/CairoDesktop.Common/CairoDesktop.Common.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedShell" Version="0.0.231" />
+    <PackageReference Include="ManagedShell" Version="0.0.240" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
   </ItemGroup>

--- a/Cairo Desktop/CairoDesktop.Common/CairoDesktop.Common.csproj
+++ b/Cairo Desktop/CairoDesktop.Common/CairoDesktop.Common.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedShell" Version="0.0.240" />
+    <PackageReference Include="ManagedShell" Version="0.0.243" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
   </ItemGroup>

--- a/Cairo Desktop/CairoDesktop.Configuration/Properties/Settings.Designer.cs
+++ b/Cairo Desktop/CairoDesktop.Configuration/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace CairoDesktop.Configuration.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.7.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.8.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -657,6 +657,18 @@ namespace CairoDesktop.Configuration.Properties {
             }
             set {
                 this["EnableMenuBarAutoHide"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public int AutoHideShowDelayMs {
+            get {
+                return ((int)(this["AutoHideShowDelayMs"]));
+            }
+            set {
+                this["AutoHideShowDelayMs"] = value;
             }
         }
     }

--- a/Cairo Desktop/CairoDesktop.Configuration/Properties/Settings.settings
+++ b/Cairo Desktop/CairoDesktop.Configuration/Properties/Settings.settings
@@ -161,5 +161,8 @@
     <Setting Name="EnableMenuBarAutoHide" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="AutoHideShowDelayMs" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/Cairo Desktop/CairoDesktop.Configuration/Settings.cs
+++ b/Cairo Desktop/CairoDesktop.Configuration/Settings.cs
@@ -373,6 +373,12 @@ namespace CairoDesktop.Configuration
             {
                 if (cairoSettings.TaskbarMode != value)
                 {
+                    if (value == 2 && EnableMenuBarAutoHide && TaskbarPosition == 1)
+                    {
+                        // We cannot have multiple auto-hide bars on the same screen edge
+                        EnableMenuBarAutoHide = false;
+                    }
+
                     cairoSettings.TaskbarMode = value;
                 }
             }
@@ -388,6 +394,12 @@ namespace CairoDesktop.Configuration
             {
                 if (cairoSettings.TaskbarPosition != value)
                 {
+                    if (value == 1 && EnableMenuBarAutoHide && TaskbarMode == 2)
+                    {
+                        // We cannot have multiple auto-hide bars on the same screen edge
+                        EnableMenuBarAutoHide = false;
+                    }
+
                     cairoSettings.TaskbarPosition = value;
                 }
             }
@@ -812,6 +824,12 @@ namespace CairoDesktop.Configuration
             {
                 if (cairoSettings.EnableMenuBarAutoHide != value)
                 {
+                    if (value && TaskbarPosition == 1 && TaskbarMode == 2)
+                    {
+                        // We cannot have multiple auto-hide bars on the same screen edge
+                        TaskbarPosition = 0;
+                    }
+
                     cairoSettings.EnableMenuBarAutoHide = value;
                 }
             }

--- a/Cairo Desktop/CairoDesktop.Configuration/Settings.cs
+++ b/Cairo Desktop/CairoDesktop.Configuration/Settings.cs
@@ -897,6 +897,21 @@ namespace CairoDesktop.Configuration
                 }
             }
         }
+
+        public int AutoHideShowDelayMs
+        {
+            get
+            {
+                return cairoSettings.AutoHideShowDelayMs;
+            }
+            set
+            {
+                if (cairoSettings.AutoHideShowDelayMs != value)
+                {
+                    cairoSettings.AutoHideShowDelayMs = value;
+                }
+            }
+        }
         #endregion
 
         #region Logging

--- a/Cairo Desktop/CairoDesktop.Configuration/app.config
+++ b/Cairo Desktop/CairoDesktop.Configuration/app.config
@@ -166,6 +166,9 @@
       <setting name="EnableMenuBarAutoHide" serializeAs="String">
         <value>False</value>
       </setting>
+      <setting name="AutoHideShowDelayMs" serializeAs="String">
+        <value>0</value>
+      </setting>
     </CairoDesktop.Configuration.Properties.Settings>
   </userSettings>
   <startup>

--- a/Cairo Desktop/CairoDesktop.Localization/DisplayString.cs
+++ b/Cairo Desktop/CairoDesktop.Localization/DisplayString.cs
@@ -647,6 +647,8 @@ namespace CairoDesktop.Localization
 
         public static string sSettings_Advanced_OpenLogsFolder => getString();
 
+        public static string sSettings_Advanced_AutoHideShowDelayMs => getString();
+
         public static string sWelcome_StartTour => getString();
 
         public static string sWelcome_FinishTour => getString();

--- a/Cairo Desktop/CairoDesktop.Localization/Language.cs
+++ b/Cairo Desktop/CairoDesktop.Localization/Language.cs
@@ -273,6 +273,7 @@ namespace CairoDesktop.Localization
             { "sSettings_Advanced_LogOffNow", "Log Off Now" },
             { "sSettings_Advanced_LogOffLater", "Log Off Later" },
             { "sSettings_Advanced_OpenLogsFolder", "Open folder" },
+            { "sSettings_Advanced_AutoHideShowDelayMs", "Auto-hide show delay (ms):" },
             { "sWelcome_StartTour", "Start Tour" },
             { "sWelcome_FinishTour", "Finish Tour" },
             { "sWelcome_Welcome", "Welcome to Cairo" },


### PR DESCRIPTION
- Added setting to control how long before an auto-hide appbar is shown while the mouse is on it, and made misc related updates
- Added logic to prevent multiple auto-hidden appbars on the same edge
- Added missing space to Flat Accent theme
- Re-enabled full-width taskbar blur when using the auto-hide setting, as now it works properly
- Updated ManagedShell