### PR TITLE
Remove no-longer-necessary hack

### DIFF
--- a/Cairo Desktop/Cairo Desktop/Cairo Desktop.csproj
+++ b/Cairo Desktop/Cairo Desktop/Cairo Desktop.csproj
@@ -65,7 +65,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedShell" Version="0.0.243" />
+    <PackageReference Include="ManagedShell" Version="0.0.243-g5a76afd203" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/Cairo Desktop/Cairo Desktop/Cairo Desktop.csproj
+++ b/Cairo Desktop/Cairo Desktop/Cairo Desktop.csproj
@@ -65,7 +65,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedShell" Version="0.0.243-g5a76afd203" />
+    <PackageReference Include="ManagedShell" Version="0.0.249" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/Cairo Desktop/Cairo Desktop/MenuBar.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/MenuBar.xaml.cs
@@ -339,28 +339,7 @@ namespace CairoDesktop
 
         private void Window_LocationChanged(object sender, EventArgs e)
         {
-            double top = getDesiredTopPosition();
-
             setShadowPosition();
-
-            if (Top == top)
-            {
-                return;
-            }
-
-            Top = top;
-        }
-
-        private double getDesiredTopPosition()
-        {
-            double top;
-
-            if (AppBarEdge == AppBarEdge.Bottom) 
-                top = (Screen.Bounds.Bottom / DpiScale) - DesiredHeight;
-            else
-                top = Screen.Bounds.Y / DpiScale;
-
-            return top;
         }
 
         protected override void CustomClosing()

--- a/Cairo Desktop/Cairo Desktop/Taskbar.xaml
+++ b/Cairo Desktop/Cairo Desktop/Taskbar.xaml
@@ -15,7 +15,6 @@
     AllowDrop="True"
     Visibility="Visible"
     Loaded="TaskbarWindow_Loaded"
-    LocationChanged="TaskbarWindow_LocationChanged"
     Background="{DynamicResource ResourceKey=TaskBarWindowBackground}"
     HorizontalAlignment="Center">
     <Window.Resources>

--- a/Cairo Desktop/Cairo Desktop/Taskbar.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/Taskbar.xaml.cs
@@ -482,17 +482,6 @@ namespace CairoDesktop
             NativeMethods.SetForegroundWindow(Handle);
         }
 
-        private void TaskbarWindow_LocationChanged(object sender, EventArgs e)
-        {
-            // primarily for win7/8, they will set up the appbar correctly but then put it in the wrong place
-            double desiredTop = getDesiredTopPosition();
-
-            if (Top != desiredTop)
-            {
-                Top = desiredTop;
-            }
-        }
-
         public override void AfterAppBarPos(bool isSameCoords, NativeMethods.Rect rect)
         {
             base.AfterAppBarPos(isSameCoords, rect);

--- a/Cairo Desktop/CairoDesktop.Common/CairoDesktop.Common.csproj
+++ b/Cairo Desktop/CairoDesktop.Common/CairoDesktop.Common.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedShell" Version="0.0.243-g5a76afd203" />
+    <PackageReference Include="ManagedShell" Version="0.0.249" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
   </ItemGroup>

--- a/Cairo Desktop/CairoDesktop.Common/CairoDesktop.Common.csproj
+++ b/Cairo Desktop/CairoDesktop.Common/CairoDesktop.Common.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedShell" Version="0.0.243" />
+    <PackageReference Include="ManagedShell" Version="0.0.243-g5a76afd203" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
   </ItemGroup>


### PR DESCRIPTION
With recent ManagedShell, this workaround for Windows 7 doesn't seem to be needed any more in my testing.