### PR TITLE
Fix fast screen setup when device name changes

### DIFF
--- a/Cairo Desktop/Cairo Desktop/Services/AppBarWindowService.cs
+++ b/Cairo Desktop/Cairo Desktop/Services/AppBarWindowService.cs
@@ -71,7 +71,7 @@ namespace CairoDesktop.Services
                 return;
             }
 
-            if (EnableMultiMon)
+            if (EnableMultiMon && !args.IsFastSetup)
             {
                 foreach (AppBarScreen screen in _windowManager.ScreenState)
                 {

--- a/Cairo Desktop/Cairo Desktop/Services/WindowManager.cs
+++ b/Cairo Desktop/Cairo Desktop/Services/WindowManager.cs
@@ -180,7 +180,12 @@ namespace CairoDesktop.Services
                     else
                     {
                         // if this is only a DPI change, screens will be the same but we still need to reposition
-                        RefreshWindows(reason, false);
+                        RefreshWindows(new WindowManagerEventArgs
+                        {
+                            DisplaysChanged = false,
+                            IsFastSetup = false,
+                            Reason = reason
+                        });
                     }
 
                     pendingDisplayEvents--;
@@ -226,7 +231,12 @@ namespace CairoDesktop.Services
             // if we have 1 display before and after, skip setup and just refresh with new primary screen information
             if (openScreens.Count == 1 && sysScreens.Count == 1)
             {
-                RefreshWindows(reason, true);
+                RefreshWindows(new WindowManagerEventArgs
+                {
+                    DisplaysChanged = true,
+                    IsFastSetup = true,
+                    Reason = reason
+                });
 
                 _logger.LogDebug("Completed fast display setup");
                 return;
@@ -263,7 +273,12 @@ namespace CairoDesktop.Services
                 ProcessRemovedScreens(removedScreens);
 
                 // refresh existing window screen properties with updated screen information
-                RefreshWindows(reason, true);
+                RefreshWindows(new WindowManagerEventArgs
+                {
+                    DisplaysChanged = true,
+                    IsFastSetup = false,
+                    Reason = reason
+                });
             }
 
             // open windows on newly added screens
@@ -317,11 +332,9 @@ namespace CairoDesktop.Services
             }
         }
 
-        private void RefreshWindows(ScreenSetupReason reason, bool displaysChanged)
+        private void RefreshWindows(WindowManagerEventArgs args)
         {
             _logger.LogDebug("Refreshing screen information for existing windows");
-
-            WindowManagerEventArgs args = new WindowManagerEventArgs { DisplaysChanged = displaysChanged, Reason = reason };
 
             foreach (var windowService in _windowServices)
             {

--- a/Cairo Desktop/Cairo Desktop/SupportingClasses/WindowManagerEventArgs.cs
+++ b/Cairo Desktop/Cairo Desktop/SupportingClasses/WindowManagerEventArgs.cs
@@ -6,6 +6,7 @@ namespace CairoDesktop.SupportingClasses
     public class WindowManagerEventArgs : EventArgs
     {
         public bool DisplaysChanged;
+        public bool IsFastSetup;
         public ScreenSetupReason Reason;
     }
 }


### PR DESCRIPTION
The screen device name changes with each new RDP connection to the machine. With the multi-mon options enabled, the device name mismatch was preventing us from finding a window to update screen information for when the fast path is being used.

This was easily triggered by connecting via RDP at one screen resolution, then disconnecting and connecting again with a different screen resolution.

I missed this in #770, as this is another item that was being papered over before.