### PR TITLE
Catch extension load errors that could halt init

### DIFF
--- a/Cairo Desktop/Cairo Desktop/Cairo Desktop.csproj
+++ b/Cairo Desktop/Cairo Desktop/Cairo Desktop.csproj
@@ -65,7 +65,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedShell" Version="0.0.254" />
+    <PackageReference Include="ManagedShell" Version="0.0.256" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/Cairo Desktop/Cairo Desktop/CairoApplicationInitializationService.InitializationRoutines.cs
+++ b/Cairo Desktop/Cairo Desktop/CairoApplicationInitializationService.InitializationRoutines.cs
@@ -52,8 +52,15 @@ namespace CairoDesktop
 
         void IInitializationService.LoadExtensions()
         {
-            var pluginService = _host.Services.GetService<IExtensionService>();
-            pluginService?.Start();
+            try
+            {
+                var pluginService = _host.Services.GetService<IExtensionService>();
+                pluginService?.Start();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Unable to start extension service due to exception in {ex.TargetSite?.Module}: {ex.Message}");
+            }
         }
 
         void IInitializationService.WriteApplicationDebugInfoToConsole(Version productVersion)

--- a/Cairo Desktop/Cairo Desktop/MenuBar.xaml
+++ b/Cairo Desktop/Cairo Desktop/MenuBar.xaml
@@ -52,7 +52,7 @@
                               Visibility="Collapsed"
                               Name="miOpenUWPSettings"
                               Click="miOpenUWPSettings_Click" />
-                    <Separator />
+                    <Separator Name="CairoMenuExtensionsSeparator" />
                     <MenuItem Header="{Binding Path=(l10n:DisplayString.sCairoMenu_Run)}"
                               Click="OpenRunWindow" />
                     <MenuItem Header="{Binding Path=(l10n:DisplayString.sCairoMenu_TaskManager)}"

--- a/Cairo Desktop/Cairo Desktop/MenuBar.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/MenuBar.xaml.cs
@@ -117,10 +117,17 @@ namespace CairoDesktop
         {
             foreach (var userControlMenuBarExtension in _cairoApplication.MenuBarExtensions.OfType<UserControlMenuBarExtension>())
             {
-                var menuExtra = userControlMenuBarExtension.StartControl(this);
-                if (menuExtra != null)
+                try
                 {
-                    MenuExtrasHost.Children.Add(menuExtra);
+                    var menuExtra = userControlMenuBarExtension.StartControl(this);
+                    if (menuExtra != null)
+                    {
+                        MenuExtrasHost.Children.Add(menuExtra);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    ShellLogger.Error($"Unable to start UserControl menu bar extension due to exception in {ex.TargetSite?.Module}: {ex.Message}");
                 }
             }
         }
@@ -135,12 +142,13 @@ namespace CairoDesktop
             // Add CairoMenu MenuItems
             if (_cairoApplication.CairoMenu.Count > 0)
             {
-                CairoMenu.Items.Insert(7, new Separator());
+                var extensionsStartIndex = CairoMenu.Items.IndexOf(CairoMenuExtensionsSeparator);
+                CairoMenu.Items.Insert(extensionsStartIndex, new Separator());
                 foreach (var cairoMenuItem in _cairoApplication.CairoMenu)
                 {
                     var menuItem = new MenuItem { Header = cairoMenuItem.Header };
                     menuItem.Click += cairoMenuItem.MenuItem_Click;
-                    CairoMenu.Items.Insert(8, menuItem);
+                    CairoMenu.Items.Insert(extensionsStartIndex + 1, menuItem);
                 }
             }
         }

--- a/Cairo Desktop/CairoDesktop.Common/CairoDesktop.Common.csproj
+++ b/Cairo Desktop/CairoDesktop.Common/CairoDesktop.Common.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedShell" Version="0.0.254" />
+    <PackageReference Include="ManagedShell" Version="0.0.256" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="System.Text.Json" Version="8.0.3" />

--- a/Cairo Desktop/CairoDesktop.Common/Logging/Other/ManagedShellLoggerProvider.cs
+++ b/Cairo Desktop/CairoDesktop.Common/Logging/Other/ManagedShellLoggerProvider.cs
@@ -7,7 +7,6 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO;
 using ManagedShell.Common;
-using ConsoleLog = ManagedShell.Common.Logging.Observers.ConsoleLog;
 
 namespace CairoDesktop.Common.Logging.Other
 {
@@ -35,8 +34,7 @@ namespace CairoDesktop.Common.Logging.Other
 
             _fileLog = new FileLog(_filename);
             _fileLog.Open();
-            ShellLogger.Attach(_fileLog);
-            ShellLogger.Attach(new ConsoleLog());
+            ShellLogger.Attach(new ILog[] { _fileLog, new ConsoleLog() }, true);
         }
 
         private void CairoSettings_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)

--- a/Cairo Desktop/CairoDesktop.Infrastructure/DependencyInjection/DependencyLoader.cs
+++ b/Cairo Desktop/CairoDesktop.Infrastructure/DependencyInjection/DependencyLoader.cs
@@ -56,12 +56,11 @@ namespace CairoDesktop.Infrastructure.DependencyInjection
                     builder.AppendFormat("{0}\n", loaderException.Message);
                 }
 
-                // TODO: Logging isn't set up at this point in startup
-                ShellLogger.Error($"DependencyLoader: Error registering module {typeLoadException.TargetSite?.Module.FullyQualifiedName}: {builder}");
+                ShellLogger.Error($"DependencyLoader: Error registering module: {builder}");
             }
             catch (Exception ex)
             {
-                ShellLogger.Error($"DependencyLoader: Error registering module {ex.TargetSite?.Module.FullyQualifiedName}: {ex.Message}");
+                ShellLogger.Error($"DependencyLoader: Error registering module: {ex.Message}");
             }
 
             return serviceCollection;

--- a/Cairo Desktop/CairoDesktop.Infrastructure/DependencyInjection/DependencyLoader.cs
+++ b/Cairo Desktop/CairoDesktop.Infrastructure/DependencyInjection/DependencyLoader.cs
@@ -57,7 +57,11 @@ namespace CairoDesktop.Infrastructure.DependencyInjection
                 }
 
                 // TODO: Logging isn't set up at this point in startup
-                ShellLogger.Error($"DependencyLoader: Error registering module: {builder}");
+                ShellLogger.Error($"DependencyLoader: Error registering module {typeLoadException.TargetSite?.Module.FullyQualifiedName}: {builder}");
+            }
+            catch (Exception ex)
+            {
+                ShellLogger.Error($"DependencyLoader: Error registering module {ex.TargetSite?.Module.FullyQualifiedName}: {ex.Message}");
             }
 
             return serviceCollection;

--- a/Cairo Desktop/CairoDesktop.Infrastructure/Services/ExtensionService.cs
+++ b/Cairo Desktop/CairoDesktop.Infrastructure/Services/ExtensionService.cs
@@ -1,4 +1,6 @@
 ﻿using CairoDesktop.Application.Interfaces;
+using Microsoft.Extensions.Logging;
+using System;
 using System.Collections.Generic;
 
 namespace CairoDesktop.Infrastructure.Services
@@ -7,19 +9,28 @@ namespace CairoDesktop.Infrastructure.Services
     {
         private readonly ICairoApplication _app;
         private readonly IEnumerable<IShellExtension> _extensions;
+        private readonly ILogger<ExtensionService> _logger;
 
-        public ExtensionService(ICairoApplication app, IEnumerable<IShellExtension> extensions)
+        public ExtensionService(ICairoApplication app, ILogger<ExtensionService> logger, IEnumerable<IShellExtension> extensions)
         {
             _app = app;
             _extensions = extensions;
+            _logger = logger;
         }
 
         public void Start()
         {
             foreach (var shellExtension in _extensions)
             {
-                shellExtension.Start();
-                _app.Extensions.Add(shellExtension);
+                try
+                {
+                    shellExtension.Start();
+                    _app.Extensions.Add(shellExtension);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError($"Unable to start shell extension: {ex.Message}");
+                }
             }
         }
 


### PR DESCRIPTION
Improves the robustness of extension loading so that extensions throwing exceptions at startup don't prevent Cairo startup.

Also added a couple adjacent improvements:
- Fixed an old TODO where logs weren't emitted early on during startup
- Improved Cairo menu item extension insertion logic so that it's not sensitive to us adding/removing items