### PR TITLE
Add togglable Places & Programs

### DIFF
--- a/Cairo Desktop/Cairo Desktop/MenuBar.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/MenuBar.xaml.cs
@@ -69,6 +69,12 @@ namespace CairoDesktop
         {
             stacksContainer.MenuBar = this;
             programsMenuControl.MenuBar = this;
+
+            if (!Settings.Instance.EnableProgramsMenu)
+                ProgramsMenu.Visibility = Visibility.Collapsed;
+
+            if (!Settings.Instance.EnablePlacesMenu)
+                PlacesMenu.Visibility = Visibility.Collapsed;
         }
 
         private void SetupMenuBarExtensions()
@@ -319,7 +325,7 @@ namespace CairoDesktop
         #region Programs menu
         internal void OpenProgramsMenu()
         {
-            if (ProgramsMenu.IsSubmenuOpen) { return; }
+            if (ProgramsMenu.IsSubmenuOpen || !Settings.Instance.EnableProgramsMenu) { return; }
 
             NativeMethods.SetForegroundWindow(Handle);
             UnAutoHideBeforeAction(() => ProgramsMenu.IsSubmenuOpen = true);

--- a/Cairo Desktop/Cairo Desktop/SettingsUI.xaml
+++ b/Cairo Desktop/Cairo Desktop/SettingsUI.xaml
@@ -426,6 +426,11 @@
                                Style="{StaticResource SettingGroupHeader}" />
                     <StackPanel Orientation="Horizontal">
                         <StackPanel Orientation="Vertical">
+                            <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=EnablePlacesMenu, UpdateSourceTrigger=PropertyChanged}"
+                                      Click="CheckBox_Click"
+                                      Name="chkEnablePlacesMenu">
+                                <Label Content="{Binding Path=(l10n:DisplayString.sPlacesMenu)}" />
+                            </CheckBox>
                             <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=EnableMenuExtraClock, UpdateSourceTrigger=PropertyChanged}"
                                       Click="CheckBox_Click"
                                       Name="chkEnableMenuExtraClock">
@@ -438,6 +443,11 @@
                             </CheckBox>
                         </StackPanel>
                         <StackPanel Orientation="Vertical" Margin="10,0,0,0">
+                            <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=EnableProgramsMenu, UpdateSourceTrigger=PropertyChanged}"
+                                      Click="CheckBox_Click"
+                                      Name="chkEnablePrgoramsMenu">
+                                <Label Content="{Binding Path=(l10n:DisplayString.sProgramsMenu)}" />
+                            </CheckBox>
                             <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=EnableMenuExtraVolume, UpdateSourceTrigger=PropertyChanged}"
                                       Click="CheckBox_Click"
                                       Name="chkEnableMenuExtraVolume">

--- a/Cairo Desktop/CairoDesktop.Common/Settings.cs
+++ b/Cairo Desktop/CairoDesktop.Common/Settings.cs
@@ -370,6 +370,20 @@ namespace CairoDesktop.Common
             set => Set(ref _enableMenuBar, value);
         }
 
+        private bool _enablePlacesMenu = true;
+        public bool EnablePlacesMenu
+        {
+            get => _enablePlacesMenu;
+            set => Set(ref _enablePlacesMenu, value);
+        }
+
+        private bool _enableProgramsMenu = true;
+        public bool EnableProgramsMenu
+        {
+            get => _enableProgramsMenu;
+            set => Set(ref _enableProgramsMenu, value);
+        }
+
         private bool _enableMenuBarShadow = true;
         public bool EnableMenuBarShadow
         {


### PR DESCRIPTION
I've added the ability to toggle the Places and Programs option in the menu bar. I'd like to disable it as i don't really use it anyways and it takes up space for my _way too big_ tray.

I'm quite unfamiliar with the code base and just went off of how everything else, i think, is done.
For translations i'm just piggy backing off of the existing translations for the 2 options.

If i made a mistake or it's not up to standard then let me know.