### PR TITLE
Use injected settings more

### DIFF
--- a/Cairo Desktop/Cairo Desktop/CairoApplication.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/CairoApplication.xaml.cs
@@ -26,6 +26,7 @@ namespace CairoDesktop
         private readonly ILogger<CairoApplication> _logger;
         private readonly IOptionsMonitor<CommandLineOptions> _options;
         private readonly IInitializationService _initializationService;
+        private readonly Settings _settings;
 
         public new static CairoApplication Current => System.Windows.Application.Current as CairoApplication;
 
@@ -36,12 +37,13 @@ namespace CairoDesktop
 
         public CairoApplication(IHost host, ILogger<CairoApplication> logger,
             IOptionsMonitor<CommandLineOptions> options,
-            IInitializationService initializationService)
+            IInitializationService initializationService, Settings settings)
         {
             Host = host;
             _logger = logger;
             _options = options;
             _initializationService = initializationService;
+            _settings = settings;
             ShutdownMode = ShutdownMode.OnExplicitShutdown;
 
             Extensions = new List<IShellExtension>();
@@ -53,6 +55,7 @@ namespace CairoDesktop
             AppVersion = ProductVersion.ToString();
 
             InitializeComponent();
+            _settings = settings;
         }
 
         protected override void OnStartup(StartupEventArgs e)
@@ -69,7 +72,7 @@ namespace CairoDesktop
 
             _initializationService.SetTheme();
 
-            if (Settings.Instance.ForceSoftwareRendering)
+            if (_settings.ForceSoftwareRendering)
             {
                 RenderOptions.ProcessRenderMode = RenderMode.SoftwareOnly;
             }

--- a/Cairo Desktop/Cairo Desktop/Commands/OpenLocationCommand.cs
+++ b/Cairo Desktop/Cairo Desktop/Commands/OpenLocationCommand.cs
@@ -121,7 +121,7 @@ namespace CairoDesktop.Commands
 
         public bool IsAvailableForShellItem(ShellItem item)
         {
-            return item.IsNavigableFolder && Settings.Instance.EnableDynamicDesktop && DesktopManager.IsEnabled;
+            return item.IsNavigableFolder && _settings.EnableDynamicDesktop && DesktopManager.IsEnabled;
         }
     }
 }

--- a/Cairo Desktop/Cairo Desktop/Commands/OpenLocationInWindowCommand.cs
+++ b/Cairo Desktop/Cairo Desktop/Commands/OpenLocationInWindowCommand.cs
@@ -16,10 +16,13 @@ namespace CairoDesktop.Commands
         public ICairoCommandInfo Info => _info;
 
         private readonly IDesktopManager _desktopManager;
+        private readonly Settings _settings;
         private readonly OpenLocationInWindowCommandInfo _info = new OpenLocationInWindowCommandInfo();
 
-        public OpenLocationInWindowCommand(IDesktopManager desktopManager) {
+        public OpenLocationInWindowCommand(IDesktopManager desktopManager, Settings settings)
+        {
             _desktopManager = desktopManager;
+            _settings = settings;
         }
 
         public bool Execute(params (string name, object value)[] parameters)
@@ -47,7 +50,7 @@ namespace CairoDesktop.Commands
             _desktopManager.IsOverlayOpen = false;
 
             var args = Environment.ExpandEnvironmentVariables(path);
-            var filename = Environment.ExpandEnvironmentVariables(Settings.Instance.FileManager);
+            var filename = Environment.ExpandEnvironmentVariables(_settings.FileManager);
 
             return ShellHelper.StartProcess(filename, $@"""{args}""");
         }

--- a/Cairo Desktop/Cairo Desktop/Desktop.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/Desktop.xaml.cs
@@ -44,6 +44,7 @@ namespace CairoDesktop
         private readonly FullScreenHelper _fullScreenHelper;
         private readonly FileOperationWorker _fileWorker;
         private readonly ISettingsUIService _settingsUiService;
+        private readonly Settings _settings;
 
         public bool AllowClose;
         public IntPtr Handle;
@@ -52,7 +53,7 @@ namespace CairoDesktop
         private Brush BackgroundBrush { get; set; }
         private Dictionary<uint, string> ContextMenuCommandUIDs = new Dictionary<uint, string>();
 
-        public Desktop(IDesktopManager desktopManager, AppBarManager appBarManager, FullScreenHelper fullScreenHelper, ISettingsUIService settingsUiService, ICommandService commandService)
+        public Desktop(IDesktopManager desktopManager, AppBarManager appBarManager, FullScreenHelper fullScreenHelper, ISettingsUIService settingsUiService, ICommandService commandService, Settings settings)
         {
             InitializeComponent();
 
@@ -62,6 +63,7 @@ namespace CairoDesktop
             _fullScreenHelper = fullScreenHelper;
             _fileWorker = new FileOperationWorker();
             _settingsUiService = settingsUiService;
+            _settings = settings;
 
             if (_desktopManager.ShellWindow != null)
             {
@@ -72,7 +74,7 @@ namespace CairoDesktop
             setGridPosition();
             setBackground();
 
-            Settings.Instance.PropertyChanged += Settings_PropertyChanged;
+            _settings.PropertyChanged += Settings_PropertyChanged;
 
             _fullScreenHelper.FullScreenApps.CollectionChanged += FullScreenApps_CollectionChanged;
         }
@@ -149,7 +151,7 @@ namespace CairoDesktop
             if (!e.Cancel)
             {
                 // unsubscribe from things
-                Settings.Instance.PropertyChanged -= Settings_PropertyChanged;
+                _settings.PropertyChanged -= Settings_PropertyChanged;
                 _fullScreenHelper.FullScreenApps.CollectionChanged -= FullScreenApps_CollectionChanged;
             }
         }
@@ -236,7 +238,7 @@ namespace CairoDesktop
 
         private void FullScreenApps_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
         {
-            if (Settings.Instance.DesktopBackgroundType == "cairoVideoWallpaper")
+            if (_settings.DesktopBackgroundType == "cairoVideoWallpaper")
             {
                 // pause video if we see a full screen app to preserve system performance.
 
@@ -301,7 +303,7 @@ namespace CairoDesktop
 
             grid.Width = WindowManager.PrimaryMonitorWorkArea.Width / DpiHelper.DpiScale;
 
-            if (Settings.Instance.TaskbarMode == 1)
+            if (_settings.TaskbarMode == 1)
             {
                 // special case, since work area is not reduced with this setting
                 // this keeps the desktop going beneath the TaskBar
@@ -312,7 +314,7 @@ namespace CairoDesktop
 
                 grid.Height = (WindowManager.PrimaryMonitorWorkArea.Height / DpiHelper.DpiScale) - ((screen.Bounds.Bottom - workAreaRect.Bottom) / dpiScale);
 
-                if (Settings.Instance.TaskbarEdge == AppBarEdge.Top)
+                if (_settings.TaskbarEdge == AppBarEdge.Top)
                 {
                     top += (workAreaRect.Top - SystemInformation.WorkingArea.Top) / dpiScale;
                 }
@@ -353,7 +355,7 @@ namespace CairoDesktop
 
         private Brush GetCairoBackgroundBrush()
         {
-            switch (Settings.Instance.DesktopBackgroundType)
+            switch (_settings.DesktopBackgroundType)
             {
                 case "cairoImageWallpaper":
                     return GetCairoBackgroundBrush_Image();
@@ -415,11 +417,11 @@ namespace CairoDesktop
 
         private Brush GetCairoBackgroundBrush_Image()
         {
-            string wallpaper = Settings.Instance.CairoBackgroundImagePath;
+            string wallpaper = _settings.CairoBackgroundImagePath;
 
             CairoWallpaperStyle wallpaperStyle = CairoWallpaperStyle.Stretch;
-            if (Enum.IsDefined(typeof(CairoWallpaperStyle), Settings.Instance.CairoBackgroundImageStyle))
-                wallpaperStyle = (CairoWallpaperStyle)Settings.Instance.CairoBackgroundImageStyle;
+            if (Enum.IsDefined(typeof(CairoWallpaperStyle), _settings.CairoBackgroundImageStyle))
+                wallpaperStyle = (CairoWallpaperStyle)_settings.CairoBackgroundImageStyle;
 
             return GetCairoBackgroundBrush_Image(wallpaper, wallpaperStyle) ?? GetCairoBackgroundBrush_Windows();
         }
@@ -450,7 +452,7 @@ namespace CairoDesktop
 
         private Brush GetCairoBackgroundBrush_Video()
         {
-            string wallpaper = Settings.Instance.CairoBackgroundVideoPath;
+            string wallpaper = _settings.CairoBackgroundVideoPath;
             if (File.Exists(wallpaper))
             {
                 // https://docs.microsoft.com/en-us/dotnet/framework/wpf/graphics-multimedia/how-to-paint-an-area-with-a-video
@@ -556,8 +558,8 @@ namespace CairoDesktop
                 backgroundImageBrush = new ImageBrush(backgroundBitmapImage);
 
                 CairoWallpaperStyle wallpaperStyle = CairoWallpaperStyle.Stretch;
-                if (Enum.IsDefined(typeof(CairoWallpaperStyle), Settings.Instance.BingWallpaperStyle))
-                    wallpaperStyle = (CairoWallpaperStyle)Settings.Instance.BingWallpaperStyle;
+                if (Enum.IsDefined(typeof(CairoWallpaperStyle), _settings.BingWallpaperStyle))
+                    wallpaperStyle = (CairoWallpaperStyle)_settings.BingWallpaperStyle;
 
                 switch (wallpaperStyle)
                 {
@@ -621,8 +623,8 @@ namespace CairoDesktop
                 backgroundImageBrush = new ImageBrush(backgroundBitmapImage);
 
                 CairoWallpaperStyle wallpaperStyle = CairoWallpaperStyle.Stretch;
-                if (Enum.IsDefined(typeof(CairoWallpaperStyle), Settings.Instance.BingWallpaperStyle))
-                    wallpaperStyle = (CairoWallpaperStyle)Settings.Instance.BingWallpaperStyle;
+                if (Enum.IsDefined(typeof(CairoWallpaperStyle), _settings.BingWallpaperStyle))
+                    wallpaperStyle = (CairoWallpaperStyle)_settings.BingWallpaperStyle;
 
                 switch (wallpaperStyle)
                 {

--- a/Cairo Desktop/Cairo Desktop/Desktop.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/Desktop.xaml.cs
@@ -209,10 +209,10 @@ namespace CairoDesktop
                 case MouseButton.Middle:
                     break;
                 case MouseButton.XButton1:
-                    _desktopManager.NavigationManager.NavigateBackward();
+                    if (_settings.EnableDynamicDesktop) _desktopManager.NavigationManager.NavigateBackward();
                     break;
                 case MouseButton.XButton2:
-                    _desktopManager.NavigationManager.NavigateForward();
+                    if (_settings.EnableDynamicDesktop) _desktopManager.NavigationManager.NavigateForward();
                     break;
             }
         }

--- a/Cairo Desktop/Cairo Desktop/DesktopIcons.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/DesktopIcons.xaml.cs
@@ -26,6 +26,7 @@ namespace CairoDesktop
     {
         private readonly ICommandService _commandService;
         private readonly IDesktopManager _desktopManager;
+        private readonly Settings _settings;
 
         internal bool RenameNewIcon;
         private Icon LastIconSelected;
@@ -60,14 +61,15 @@ namespace CairoDesktop
             }
         }
 
-        public DesktopIcons(IDesktopManager manager, ICommandService commandService)
+        public DesktopIcons(IDesktopManager manager, ICommandService commandService, Settings settings)
         {
             InitializeComponent();
 
             _commandService = commandService;
             _desktopManager = manager;
+            _settings = settings;
 
-            Settings.Instance.PropertyChanged += Settings_PropertyChanged;
+            _settings.PropertyChanged += Settings_PropertyChanged;
 
             setPosition();
             SetIconLocation();
@@ -118,7 +120,7 @@ namespace CairoDesktop
             int xOffset = 7;
             int yOffset = 13;
 
-            if (Settings.Instance.DesktopLabelPosition == 1)
+            if (_settings.DesktopLabelPosition == 1)
                 xOffset = 0;
 
             panel.Margin = new Thickness(xOffset, yOffset, 0, 0);

--- a/Cairo Desktop/Cairo Desktop/DesktopNavigationToolbar.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/DesktopNavigationToolbar.xaml.cs
@@ -33,6 +33,7 @@ namespace CairoDesktop
         private LowLevelKeyboardListener lowLevelKeyboardListener;
         private readonly ICairoApplication _cairoApplication;
         private readonly IDesktopManager _desktopManager;
+        private readonly Settings _settings;
 
         private static DependencyProperty navigationManagerProperty = DependencyProperty.Register("NavigationManager", typeof(NavigationManager), typeof(DesktopNavigationToolbar));
         private static DependencyProperty isShiftKeyHeldProperty = DependencyProperty.Register("isShiftKeyHeld", typeof(bool), typeof(DesktopNavigationToolbar), new PropertyMetadata(new bool()));
@@ -73,12 +74,13 @@ namespace CairoDesktop
             }
         }
 
-        public DesktopNavigationToolbar(ICairoApplication cairoApplication, IDesktopManager manager)
+        public DesktopNavigationToolbar(ICairoApplication cairoApplication, IDesktopManager manager, Settings settings)
         {
             InitializeComponent();
 
             _cairoApplication = cairoApplication;
             _desktopManager = manager;
+            _settings = settings;
 
             // set up browse context menu (is dynamically constructed)
             browseContextMenu = new ContextMenu();
@@ -147,12 +149,12 @@ namespace CairoDesktop
 
         private void SetPosition(uint x = 0, uint y = 0)
         {
-            if (Settings.Instance.DesktopNavigationToolbarLocation != default)
+            if (_settings.DesktopNavigationToolbarLocation != default)
             {
                 Point desiredLocation = new Point()
                 {
-                    X = PercentToAbsPos(Settings.Instance.DesktopNavigationToolbarLocation.X, ActualWidth, WindowManager.PrimaryMonitorSize.Width),
-                    Y = PercentToAbsPos(Settings.Instance.DesktopNavigationToolbarLocation.Y, ActualHeight, WindowManager.PrimaryMonitorSize.Height)
+                    X = PercentToAbsPos(_settings.DesktopNavigationToolbarLocation.X, ActualWidth, WindowManager.PrimaryMonitorSize.Width),
+                    Y = PercentToAbsPos(_settings.DesktopNavigationToolbarLocation.Y, ActualHeight, WindowManager.PrimaryMonitorSize.Height)
                 };
 
                 if (PointExistsOnScreen(desiredLocation))
@@ -323,7 +325,7 @@ namespace CairoDesktop
         #region Home menu
         private void SetHomeMenuItem_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.DesktopDirectory = NavigationManager.CurrentItem.Path;
+            _settings.DesktopDirectory = NavigationManager.CurrentItem.Path;
         }
         #endregion
 
@@ -503,9 +505,9 @@ namespace CairoDesktop
             var newPoint = new Point(AbsToPercentPos(Left, ActualWidth, WindowManager.PrimaryMonitorSize.Width),
                 AbsToPercentPos(Top, ActualHeight, WindowManager.PrimaryMonitorSize.Height));
 
-            if (!newPoint.Equals(Settings.Instance.DesktopNavigationToolbarLocation))
+            if (!newPoint.Equals(_settings.DesktopNavigationToolbarLocation))
             {
-                Settings.Instance.DesktopNavigationToolbarLocation = newPoint;
+                _settings.DesktopNavigationToolbarLocation = newPoint;
             }
         }
         #endregion

--- a/Cairo Desktop/Cairo Desktop/DesktopOverlay.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/DesktopOverlay.xaml.cs
@@ -18,14 +18,16 @@ namespace CairoDesktop
     {
         private readonly IDesktopManager _desktopManager;
         private readonly AppBarManager _appBarManager;
+        private readonly Settings _settings;
         public IntPtr Handle;
 
-        public DesktopOverlay(IDesktopManager manager, AppBarManager appBarManager)
+        public DesktopOverlay(IDesktopManager manager, AppBarManager appBarManager, Settings settings)
         {
             InitializeComponent();
             
             _desktopManager = manager;
             _appBarManager = appBarManager;
+            _settings = settings;
 
             ResetPosition();
         }
@@ -35,7 +37,7 @@ namespace CairoDesktop
             double top = System.Windows.Forms.SystemInformation.WorkingArea.Top / DpiHelper.DpiScale;
             double taskbarHeight = 0;
 
-            if (Settings.Instance.TaskbarMode == 1)
+            if (_settings.TaskbarMode == 1)
             {
                 // special case, since work area is not reduced with this setting
                 // this keeps the desktop going beneath the TaskBar
@@ -47,7 +49,7 @@ namespace CairoDesktop
                 taskbarHeight = (screen.Bounds.Bottom - workAreaRect.Bottom) / dpiScale;
 
                 // top TaskBar means we should push down
-                if (Settings.Instance.TaskbarEdge == AppBarEdge.Top)
+                if (_settings.TaskbarEdge == AppBarEdge.Top)
                 {
                     top = workAreaRect.Top / dpiScale;
                 }

--- a/Cairo Desktop/Cairo Desktop/Services/AppBarWindowService.cs
+++ b/Cairo Desktop/Cairo Desktop/Services/AppBarWindowService.cs
@@ -20,14 +20,16 @@ namespace CairoDesktop.Services
         protected readonly ICairoApplication _cairoApplication;
         protected readonly ShellManager _shellManager;
         protected readonly IWindowManager _windowManager;
+        protected readonly Settings _settings;
 
-        protected AppBarWindowService(ICairoApplication cairoApplication, ShellManagerService shellManagerService, IWindowManager windowManager)
+        protected AppBarWindowService(ICairoApplication cairoApplication, ShellManagerService shellManagerService, IWindowManager windowManager, Settings settings)
         {
             _cairoApplication = cairoApplication;
             _shellManager = shellManagerService.ShellManager;
             _windowManager = windowManager;
+            _settings = settings;
 
-            Settings.Instance.PropertyChanged += Settings_PropertyChanged;
+            _settings.PropertyChanged += Settings_PropertyChanged;
         }
 
         public void Register()
@@ -37,7 +39,7 @@ namespace CairoDesktop.Services
 
         public virtual void Dispose()
         {
-            Settings.Instance.PropertyChanged -= Settings_PropertyChanged;
+            _settings.PropertyChanged -= Settings_PropertyChanged;
         }
 
         private void Settings_PropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Cairo Desktop/Cairo Desktop/Services/FirstRunService.cs
+++ b/Cairo Desktop/Cairo Desktop/Services/FirstRunService.cs
@@ -15,14 +15,16 @@ namespace CairoDesktop.Services
         private readonly IAppGrabber _appGrabber;
         private readonly ICairoApplication _cairoApplication;
         private readonly ILogger<FirstRunService> _logger;
+        private readonly Settings _settings;
 
         private readonly bool _forceTour;
 
-        public FirstRunService(ICairoApplication cairoApplication, IAppGrabber appGrabber, ILogger<FirstRunService> logger, IOptionsMonitor<CommandLineOptions> options)
+        public FirstRunService(ICairoApplication cairoApplication, IAppGrabber appGrabber, ILogger<FirstRunService> logger, IOptionsMonitor<CommandLineOptions> options, Settings settings)
         {
             _appGrabber = appGrabber;
             _cairoApplication = cairoApplication;
             _logger = logger;
+            _settings = settings;
 
             try
             {
@@ -38,7 +40,7 @@ namespace CairoDesktop.Services
 
         private void FirstRun()
         {
-            if (Settings.Instance.IsFirstRun || _forceTour)
+            if (_settings.IsFirstRun || _forceTour)
             {
                 _cairoApplication.Dispatch(() =>
                 {
@@ -49,7 +51,7 @@ namespace CairoDesktop.Services
 
         private void ShowWelcome()
         {
-            Welcome welcome = new Welcome(_cairoApplication, _appGrabber);
+            Welcome welcome = new Welcome(_cairoApplication, _appGrabber, _settings);
             welcome.Show();
         }
     }

--- a/Cairo Desktop/Cairo Desktop/Services/MenuBarWindowService.cs
+++ b/Cairo Desktop/Cairo Desktop/Services/MenuBarWindowService.cs
@@ -14,15 +14,15 @@ namespace CairoDesktop.Services
         private readonly IApplicationUpdateService _updateService;
         private readonly ICommandService _commandService;
 
-        public MenuBarWindowService(ICairoApplication cairoApplication, ShellManagerService shellManagerService, IWindowManager windowManager, IAppGrabber appGrabber, IApplicationUpdateService updateService, ISettingsUIService settingsUiService, ICommandService commandService) : base(cairoApplication, shellManagerService, windowManager)
+        public MenuBarWindowService(ICairoApplication cairoApplication, ShellManagerService shellManagerService, IWindowManager windowManager, IAppGrabber appGrabber, IApplicationUpdateService updateService, ISettingsUIService settingsUiService, ICommandService commandService, Settings settings) : base(cairoApplication, shellManagerService, windowManager, settings)
         {
             _appGrabber = appGrabber;
             _settingsUiService = settingsUiService;
             _updateService = updateService;
             _commandService = commandService;
 
-            EnableMultiMon = Settings.Instance.EnableMenuBarMultiMon;
-            EnableService = Settings.Instance.EnableMenuBar;
+            EnableMultiMon = _settings.EnableMenuBarMultiMon;
+            EnableService = _settings.EnableMenuBar;
         }
 
         protected override void HandleSettingChange(string setting)
@@ -30,17 +30,17 @@ namespace CairoDesktop.Services
             switch (setting)
             {
                 case "EnableMenuBar":
-                    HandleEnableServiceChanged(Settings.Instance.EnableMenuBar);
+                    HandleEnableServiceChanged(_settings.EnableMenuBar);
                     break;
                 case "EnableMenuBarMultiMon":
-                    HandleEnableMultiMonChanged(Settings.Instance.EnableMenuBarMultiMon);
+                    HandleEnableMultiMonChanged(_settings.EnableMenuBarMultiMon);
                     break;
             }
         }
 
         protected override void OpenWindow(AppBarScreen screen)
         {
-            MenuBar newMenuBar = new MenuBar(_cairoApplication, _shellManager, _windowManager, _appGrabber, _updateService, _settingsUiService, _commandService, screen, Settings.Instance.MenuBarEdge, Settings.Instance.EnableMenuBarAutoHide ? AppBarMode.AutoHide : AppBarMode.Normal);
+            MenuBar newMenuBar = new MenuBar(_cairoApplication, _shellManager, _windowManager, _appGrabber, _updateService, _settingsUiService, _commandService, _settings, screen, _settings.MenuBarEdge, _settings.EnableMenuBarAutoHide ? AppBarMode.AutoHide : AppBarMode.Normal);
             Windows.Add(newMenuBar);
             newMenuBar.Show();
         }

--- a/Cairo Desktop/Cairo Desktop/Services/SettingsUIService.cs
+++ b/Cairo Desktop/Cairo Desktop/Services/SettingsUIService.cs
@@ -1,5 +1,6 @@
 ﻿using CairoDesktop.AppGrabber;
 using CairoDesktop.Application.Interfaces;
+using CairoDesktop.Common;
 using CairoDesktop.Infrastructure.Services;
 
 namespace CairoDesktop.Services
@@ -12,11 +13,12 @@ namespace CairoDesktop.Services
         private readonly ShellManagerService _shellManager;
         private readonly IThemeService _themeService;
         private readonly IApplicationUpdateService _updateService;
+        private readonly Settings _settings;
 
         internal SettingsUI SettingsUi;
         
         public SettingsUIService(ICairoApplication cairoApplication, IAppGrabber appGrabber, IApplicationUpdateService updateService,
-            ShellManagerService shellManager, IThemeService themeService, ICommandService commandService)
+            ShellManagerService shellManager, IThemeService themeService, ICommandService commandService, Settings settings)
         {
             _appGrabber = appGrabber;
             _cairoApplication = cairoApplication;
@@ -24,13 +26,14 @@ namespace CairoDesktop.Services
             _shellManager = shellManager;
             _themeService = themeService;
             _updateService = updateService;
+            _settings = settings;
         }
         
         public void Show()
         {
             if (SettingsUi == null)
             {
-                SettingsUi = new SettingsUI(_cairoApplication, this, _shellManager, _updateService, _appGrabber, _themeService, _commandService);
+                SettingsUi = new SettingsUI(_cairoApplication, this, _shellManager, _updateService, _appGrabber, _themeService, _commandService, _settings);
             }
             
             SettingsUi.Show();

--- a/Cairo Desktop/Cairo Desktop/Services/TaskbarWindowService.cs
+++ b/Cairo Desktop/Cairo Desktop/Services/TaskbarWindowService.cs
@@ -18,15 +18,16 @@ namespace CairoDesktop.Services
             IWindowManager windowManager,
             IDesktopManager desktopManager, 
             IAppGrabber appGrabber,
-            ICommandService commandService) 
-            : base(cairoApplication, shellManagerService, windowManager)
+            ICommandService commandService,
+            Settings settings) 
+            : base(cairoApplication, shellManagerService, windowManager, settings)
         {
             _appGrabber = appGrabber;
             _desktopManager = desktopManager;
             _commandService = commandService;
 
-            EnableMultiMon = Settings.Instance.EnableTaskbarMultiMon;
-            EnableService = Settings.Instance.EnableTaskbar;
+            EnableMultiMon = _settings.EnableTaskbarMultiMon;
+            EnableService = _settings.EnableTaskbar;
 
             if (EnableService)
             {
@@ -40,19 +41,19 @@ namespace CairoDesktop.Services
             switch (setting)
             {
                 case "EnableTaskbar":
-                    _shellManager.ExplorerHelper.HideExplorerTaskbar = Settings.Instance.EnableTaskbar;
+                    _shellManager.ExplorerHelper.HideExplorerTaskbar = _settings.EnableTaskbar;
 
-                    HandleEnableServiceChanged(Settings.Instance.EnableTaskbar);
+                    HandleEnableServiceChanged(_settings.EnableTaskbar);
                     break;
                 case "EnableTaskbarMultiMon":
-                    HandleEnableMultiMonChanged(Settings.Instance.EnableTaskbarMultiMon);
+                    HandleEnableMultiMonChanged(_settings.EnableTaskbarMultiMon);
                     break;
             }
         }
 
         private void AppBarEvent(object sender, AppBarEventArgs e)
         {
-            if (Settings.Instance.TaskbarMode == 2)
+            if (_settings.TaskbarMode == 2)
             {
                 if (sender is MenuBar menuBar)
                 {
@@ -82,7 +83,7 @@ namespace CairoDesktop.Services
 
         protected override void OpenWindow(AppBarScreen screen)
         {
-            Taskbar newTaskbar = new Taskbar(_cairoApplication, _shellManager, _windowManager, _desktopManager, _appGrabber, _commandService, screen, Settings.Instance.TaskbarEdge, Settings.Instance.TaskbarMode);
+            Taskbar newTaskbar = new Taskbar(_cairoApplication, _shellManager, _windowManager, _desktopManager, _appGrabber, _commandService, _settings, screen, _settings.TaskbarEdge, _settings.TaskbarMode);
             Windows.Add(newTaskbar);
             newTaskbar.Show();
         }

--- a/Cairo Desktop/Cairo Desktop/SettingsUI.xaml
+++ b/Cairo Desktop/Cairo Desktop/SettingsUI.xaml
@@ -301,7 +301,7 @@
                                   DropDownClosed="DropDown_Changed"
                                   IsDropDownOpen="False"
                                   IsEditable="False"
-                                  SelectedValue="{Binding Source={x:Static Settings:Settings.Instance}, Path=Language, UpdateSourceTrigger=PropertyChanged}" />
+                                  SelectedValue="{Binding Path=Language, UpdateSourceTrigger=PropertyChanged}" />
                     </StackPanel>
                     <StackPanel Orientation="Horizontal">
                         <TextBlock Text="{Binding Path=(l10n:DisplayString.sSettings_General_Theme)}"
@@ -309,11 +309,11 @@
                         <ComboBox Name="cboThemeSelect"
                                   IsDropDownOpen="False"
                                   IsEditable="False"
-                                  SelectedValue="{Binding Source={x:Static Settings:Settings.Instance}, Path=Theme, UpdateSourceTrigger=PropertyChanged}" />
+                                  SelectedValue="{Binding Path=Theme, UpdateSourceTrigger=PropertyChanged}" />
                     </StackPanel>
                     <TextBlock Text="{Binding Path=(l10n:DisplayString.sSettings_General_FilesAndFolders)}"
                                Style="{StaticResource SettingGroupHeader}" />
-                    <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=FoldersOpenDesktopOverlay, UpdateSourceTrigger=PropertyChanged}"
+                    <CheckBox IsChecked="{Binding Path=FoldersOpenDesktopOverlay, UpdateSourceTrigger=PropertyChanged}"
                               Name="chkFoldersOpenDesktopOverlay">
                         <Label Content="{Binding Path=(l10n:DisplayString.sSettings_General_FoldersOpenDesktopOverlay)}" />
                     </CheckBox>
@@ -328,11 +328,11 @@
                         <ComboBox Name="cboDefaultProgramsCategory"
                                   IsDropDownOpen="False"
                                   IsEditable="False"
-                                  SelectedValue="{Binding Source={x:Static Settings:Settings.Instance}, Path=DefaultProgramsCategory, UpdateSourceTrigger=PropertyChanged}"
+                                  SelectedValue="{Binding Path=DefaultProgramsCategory, UpdateSourceTrigger=PropertyChanged}"
                                   Width="170" />
                     </StackPanel>
                     <StackPanel Orientation="Horizontal">
-                        <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=EnableCairoMenuHotKey, UpdateSourceTrigger=PropertyChanged}"
+                        <CheckBox IsChecked="{Binding Path=EnableCairoMenuHotKey, UpdateSourceTrigger=PropertyChanged}"
                                   Name="chkEnableCairoMenuHotKey">
                             <Label Content="{Binding Path=(l10n:DisplayString.sSettings_MenuBar_EnableCairoMenuHotKey)}" />
                         </CheckBox>
@@ -343,7 +343,7 @@
                                   Width="55"
                                   Margin="5,-1,0,0"
                                   SelectionChanged="cboCairoMenuHotKey_OnSelectionChanged"
-                                  SelectedValue="{Binding Mode=OneWay, Source={x:Static Settings:Settings.Instance}, Path=CairoMenuHotKey[0], UpdateSourceTrigger=PropertyChanged}" />
+                                  SelectedValue="{Binding Mode=OneWay, Path=CairoMenuHotKey[0], UpdateSourceTrigger=PropertyChanged}" />
                         <ComboBox Name="cboCairoMenuHotKeyMod2"
                                   IsEnabled="{Binding IsChecked, ElementName=chkEnableCairoMenuHotKey}"
                                   IsDropDownOpen="False"
@@ -351,7 +351,7 @@
                                   Width="55"
                                   Margin="5,-1,0,0"
                                   SelectionChanged="cboCairoMenuHotKey_OnSelectionChanged"
-                                  SelectedValue="{Binding Mode=OneWay, Source={x:Static Settings:Settings.Instance}, Path=CairoMenuHotKey[1], UpdateSourceTrigger=PropertyChanged}" />
+                                  SelectedValue="{Binding Mode=OneWay, Path=CairoMenuHotKey[1], UpdateSourceTrigger=PropertyChanged}" />
                         <ComboBox Name="cboCairoMenuHotKeyKey"
                                   IsEnabled="{Binding IsChecked, ElementName=chkEnableCairoMenuHotKey}"
                                   IsDropDownOpen="False"
@@ -359,28 +359,28 @@
                                   Width="40"
                                   Margin="5,-1,0,0"
                                   SelectionChanged="cboCairoMenuHotKey_OnSelectionChanged"
-                                  SelectedValue="{Binding Mode=OneWay, Source={x:Static Settings:Settings.Instance}, Path=CairoMenuHotKey[2], UpdateSourceTrigger=PropertyChanged}" />
+                                  SelectedValue="{Binding Mode=OneWay, Path=CairoMenuHotKey[2], UpdateSourceTrigger=PropertyChanged}" />
                     </StackPanel>
-                    <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=ShowHibernate, UpdateSourceTrigger=PropertyChanged}"
+                    <CheckBox IsChecked="{Binding Path=ShowHibernate, UpdateSourceTrigger=PropertyChanged}"
                               Name="chkShowHibernate">
                         <Label Content="{Binding Path=(l10n:DisplayString.sSettings_MenuBar_ShowHibernate)}" />
                     </CheckBox>
                     <TextBlock Text="{Binding Path=(l10n:DisplayString.sSettings_Appearance)}"
                                Style="{StaticResource SettingGroupHeader}" />
-                    <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=EnableMenuBarAutoHide, UpdateSourceTrigger=PropertyChanged}"
+                    <CheckBox IsChecked="{Binding Path=EnableMenuBarAutoHide, UpdateSourceTrigger=PropertyChanged}"
                               Name="chkEnableMenuBarAutoHide">
                         <Label Content="{Binding Path=(l10n:DisplayString.sSettings_MenuBar_EnableMenuBarAutoHide)}" />
                     </CheckBox>
-                    <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=EnableMenuBarBlur, UpdateSourceTrigger=PropertyChanged}"
+                    <CheckBox IsChecked="{Binding Path=EnableMenuBarBlur, UpdateSourceTrigger=PropertyChanged}"
                               Name="chkEnableMenuBarBlur">
                         <Label Content="{Binding Path=(l10n:DisplayString.sSettings_MenuBar_EnableMenuBarBlur)}" />
                     </CheckBox>
-                    <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=EnableMenuBarShadow, UpdateSourceTrigger=PropertyChanged}"
+                    <CheckBox IsChecked="{Binding Path=EnableMenuBarShadow, UpdateSourceTrigger=PropertyChanged}"
                               IsEnabled="{Binding IsChecked, ElementName=chkEnableMenuBarAutoHide, Converter={StaticResource invertBoolConverter}}"
                               Name="chkEnableMenuBarShadow">
                         <Label Content="{Binding Path=(l10n:DisplayString.sSettings_MenuBar_EnableMenuBarShadow)}" />
                     </CheckBox>
-                    <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=EnableMenuBarMultiMon, UpdateSourceTrigger=PropertyChanged}"
+                    <CheckBox IsChecked="{Binding Path=EnableMenuBarMultiMon, UpdateSourceTrigger=PropertyChanged}"
                               Name="chkEnableMenuBarMultiMon">
                         <Label Content="{Binding Path=(l10n:DisplayString.sSettings_MenuBar_EnableMenuBarMultiMon)}" />
                     </CheckBox>
@@ -426,34 +426,34 @@
                                Style="{StaticResource SettingGroupHeader}" />
                     <StackPanel Orientation="Horizontal">
                         <StackPanel Orientation="Vertical">
-                            <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=EnablePlacesMenu, UpdateSourceTrigger=PropertyChanged}"
+                            <CheckBox IsChecked="{Binding Path=EnablePlacesMenu, UpdateSourceTrigger=PropertyChanged}"
                                       Click="CheckBox_Click"
                                       Name="chkEnablePlacesMenu">
                                 <Label Content="{Binding Path=(l10n:DisplayString.sPlacesMenu)}" />
                             </CheckBox>
-                            <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=EnableMenuExtraClock, UpdateSourceTrigger=PropertyChanged}"
+                            <CheckBox IsChecked="{Binding Path=EnableMenuExtraClock, UpdateSourceTrigger=PropertyChanged}"
                                       Click="CheckBox_Click"
                                       Name="chkEnableMenuExtraClock">
                                 <Label Content="{Binding Path=(l10n:DisplayString.sSettings_MenuBar_EnableMenuExtraClock)}" />
                             </CheckBox>
-                            <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=EnableMenuExtraSearch, UpdateSourceTrigger=PropertyChanged}"
+                            <CheckBox IsChecked="{Binding Path=EnableMenuExtraSearch, UpdateSourceTrigger=PropertyChanged}"
                                       Click="CheckBox_Click"
                                       Name="chkEnableMenuExtraSearch">
                                 <Label Content="{Binding Path=(l10n:DisplayString.sSettings_MenuBar_EnableMenuExtraSearch)}" />
                             </CheckBox>
                         </StackPanel>
                         <StackPanel Orientation="Vertical" Margin="10,0,0,0">
-                            <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=EnableProgramsMenu, UpdateSourceTrigger=PropertyChanged}"
+                            <CheckBox IsChecked="{Binding Path=EnableProgramsMenu, UpdateSourceTrigger=PropertyChanged}"
                                       Click="CheckBox_Click"
                                       Name="chkEnablePrgoramsMenu">
                                 <Label Content="{Binding Path=(l10n:DisplayString.sProgramsMenu)}" />
                             </CheckBox>
-                            <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=EnableMenuExtraVolume, UpdateSourceTrigger=PropertyChanged}"
+                            <CheckBox IsChecked="{Binding Path=EnableMenuExtraVolume, UpdateSourceTrigger=PropertyChanged}"
                                       Click="CheckBox_Click"
                                       Name="chkEnableMenuExtraVolume">
                                 <Label Content="{Binding Path=(l10n:DisplayString.sSettings_MenuBar_EnableMenuExtraVolume)}" />
                             </CheckBox>
-                            <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=EnableMenuExtraActionCenter, UpdateSourceTrigger=PropertyChanged}"
+                            <CheckBox IsChecked="{Binding Path=EnableMenuExtraActionCenter, UpdateSourceTrigger=PropertyChanged}"
                                       Click="CheckBox_Click"
                                       Name="chkEnableMenuExtraActionCenter">
                                 <Label Content="{Binding Path=(l10n:DisplayString.sSettings_MenuBar_EnableMenuExtraActionCenter)}" />
@@ -462,7 +462,7 @@
                     </StackPanel>
                     <TextBlock Text="{Binding Path=(l10n:DisplayString.sSettings_MenuBar_NotificationArea)}"
                                Style="{StaticResource SettingGroupHeader}" />
-                    <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=EnableSysTray, UpdateSourceTrigger=PropertyChanged}"
+                    <CheckBox IsChecked="{Binding Path=EnableSysTray, UpdateSourceTrigger=PropertyChanged}"
                               Click="CheckBox_Click"
                               Name="chkEnableSysTray">
                         <Label Content="{Binding Path=(l10n:DisplayString.sSettings_MenuBar_EnableNotificationArea)}" />
@@ -515,7 +515,7 @@
             <TabItem Header="{Binding Path=(l10n:DisplayString.sSettings_Desktop)}"
                      Name="TabDesktop">
                 <StackPanel Orientation="Vertical">
-                    <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=EnableDesktop, UpdateSourceTrigger=PropertyChanged}"
+                    <CheckBox IsChecked="{Binding Path=EnableDesktop, UpdateSourceTrigger=PropertyChanged}"
                               Name="chkEnableDesktop">
                         <Label Content="{Binding Path=(l10n:DisplayString.sSettings_Desktop_EnableDesktop)}" />
                     </CheckBox>
@@ -524,7 +524,6 @@
                         <TextBox Name="txtDesktopHome">
                             <TextBox.Text>
                                 <Binding Path="DesktopDirectory"
-                                         Source="{x:Static Settings:Settings.Instance}"
                                          UpdateSourceTrigger="PropertyChanged">
                                     <Binding.ValidationRules>
                                         <supportingClasses:DirectoryPathValidationRule RequireDirectoryExists="True" />
@@ -538,7 +537,7 @@
                                 Padding="10,0">...</Button>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal">
-                        <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=EnableDesktopOverlayHotKey, UpdateSourceTrigger=PropertyChanged}"
+                        <CheckBox IsChecked="{Binding Path=EnableDesktopOverlayHotKey, UpdateSourceTrigger=PropertyChanged}"
                                   Name="chkEnableDesktopOverlayHotKey">
                             <Label Content="{Binding Path=(l10n:DisplayString.sSettings_Desktop_EnableDesktopOverlayHotKey)}" />
                         </CheckBox>
@@ -549,7 +548,7 @@
                                   Width="55"
                                   Margin="5,-1,0,0"
                                   SelectionChanged="cboDesktopOverlayHotKey_OnSelectionChanged"
-                                  SelectedValue="{Binding Mode=OneWay, Source={x:Static Settings:Settings.Instance}, Path=DesktopOverlayHotKey[0], UpdateSourceTrigger=PropertyChanged}" />
+                                  SelectedValue="{Binding Mode=OneWay, Path=DesktopOverlayHotKey[0], UpdateSourceTrigger=PropertyChanged}" />
                         <ComboBox Name="cboDesktopOverlayHotKeyMod2"
                                   IsEnabled="{Binding IsChecked, ElementName=chkEnableDesktopOverlayHotKey}"
                                   IsDropDownOpen="False"
@@ -557,7 +556,7 @@
                                   Width="55"
                                   Margin="5,-1,0,0"
                                   SelectionChanged="cboDesktopOverlayHotKey_OnSelectionChanged"
-                                  SelectedValue="{Binding Mode=OneWay, Source={x:Static Settings:Settings.Instance}, Path=DesktopOverlayHotKey[1], UpdateSourceTrigger=PropertyChanged}" />
+                                  SelectedValue="{Binding Mode=OneWay, Path=DesktopOverlayHotKey[1], UpdateSourceTrigger=PropertyChanged}" />
                         <ComboBox Name="cboDesktopOverlayHotKeyKey"
                                   IsEnabled="{Binding IsChecked, ElementName=chkEnableDesktopOverlayHotKey}"
                                   IsDropDownOpen="False"
@@ -565,7 +564,7 @@
                                   Width="40"
                                   Margin="5,-1,0,0"
                                   SelectionChanged="cboDesktopOverlayHotKey_OnSelectionChanged"
-                                  SelectedValue="{Binding Mode=OneWay, Source={x:Static Settings:Settings.Instance}, Path=DesktopOverlayHotKey[2], UpdateSourceTrigger=PropertyChanged}" />
+                                  SelectedValue="{Binding Mode=OneWay, Path=DesktopOverlayHotKey[2], UpdateSourceTrigger=PropertyChanged}" />
                     </StackPanel>
                     <TextBlock Text="{Binding Path=(l10n:DisplayString.sSettings_Appearance)}"
                                Style="{StaticResource SettingGroupHeader}" />
@@ -607,7 +606,7 @@
                     </StackPanel>
                     <TextBlock Text="{Binding Path=(l10n:DisplayString.sSettings_Desktop_DynamicDesktop)}"
                                Style="{StaticResource SettingGroupHeader}" />
-                    <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=EnableDynamicDesktop, UpdateSourceTrigger=PropertyChanged}"
+                    <CheckBox IsChecked="{Binding Path=EnableDynamicDesktop, UpdateSourceTrigger=PropertyChanged}"
                               Name="chkEnableDynamicDesktop">
                         <Label Content="{Binding Path=(l10n:DisplayString.sSettings_Desktop_EnableDynamicDesktop)}" />
                     </CheckBox>
@@ -698,7 +697,7 @@
 
             <TabItem Header="{Binding Path=(l10n:DisplayString.sSettings_Taskbar)}">
                 <StackPanel Orientation="Vertical">
-                    <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=EnableTaskbar, UpdateSourceTrigger=PropertyChanged}"
+                    <CheckBox IsChecked="{Binding Path=EnableTaskbar, UpdateSourceTrigger=PropertyChanged}"
                               Name="chkEnableTaskbar">
                         <Label Content="{Binding Path=(l10n:DisplayString.sSettings_Taskbar_EnableTaskbar)}" />
                     </CheckBox>
@@ -768,23 +767,23 @@
                             </RadioButton>
                         </StackPanel>
                     </StackPanel>
-                    <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=ShowTaskbarBadges, UpdateSourceTrigger=PropertyChanged}"
+                    <CheckBox IsChecked="{Binding Path=ShowTaskbarBadges, UpdateSourceTrigger=PropertyChanged}"
                               Name="chkHideTaskbarBadges">
                         <Label Content="{Binding Path=(l10n:DisplayString.sSettings_Taskbar_ShowBadges)}" />
                     </CheckBox>
-                    <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=ShowTaskbarLabels, UpdateSourceTrigger=PropertyChanged}"
+                    <CheckBox IsChecked="{Binding Path=ShowTaskbarLabels, UpdateSourceTrigger=PropertyChanged}"
                               Name="chkHideTaskbarLabels">
                         <Label Content="{Binding Path=(l10n:DisplayString.sSettings_Taskbar_ShowLabels)}" />
                     </CheckBox>
-                    <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=EnableTaskbarThumbnails, UpdateSourceTrigger=PropertyChanged}"
+                    <CheckBox IsChecked="{Binding Path=EnableTaskbarThumbnails, UpdateSourceTrigger=PropertyChanged}"
                               Name="chkEnableTaskbarThumbnails">
                         <Label Content="{Binding Path=(l10n:DisplayString.sSettings_Taskbar_EnableThumbnails)}" />
                     </CheckBox>
-                    <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=EnableTaskbarMultiMon, UpdateSourceTrigger=PropertyChanged}"
+                    <CheckBox IsChecked="{Binding Path=EnableTaskbarMultiMon, UpdateSourceTrigger=PropertyChanged}"
                               Name="chkEnableTaskbarMultiMon">
                         <Label Content="{Binding Path=(l10n:DisplayString.sSettings_Taskbar_EnableTaskbarMultiMon)}" />
                     </CheckBox>
-                    <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=FullWidthTaskBar, UpdateSourceTrigger=PropertyChanged}"
+                    <CheckBox IsChecked="{Binding Path=FullWidthTaskBar, UpdateSourceTrigger=PropertyChanged}"
                               Name="chkFullWidthTaskBar">
                         <Label Content="{Binding Path=(l10n:DisplayString.sSettings_Taskbar_FullWidthTaskBar)}" />
                     </CheckBox>
@@ -822,19 +821,19 @@
                                    Margin="5,3,5,4" />
                         <StackPanel Orientation="Vertical">
                             <RadioButton GroupName="rdoTaskbarMultiMonMode"
-                                         IsEnabled="{Binding Source={x:Static Settings:Settings.Instance}, Path=EnableTaskbarMultiMon, UpdateSourceTrigger=PropertyChanged}"
+                                         IsEnabled="{Binding Path=EnableTaskbarMultiMon, UpdateSourceTrigger=PropertyChanged}"
                                          Name="radTaskbarMultiMonMode0"
                                          Click="radTaskbarMultiMonMode0_Click">
                                 <Label Content="{Binding Path=(l10n:DisplayString.sSettings_Taskbar_MultiMonMode_All)}" />
                             </RadioButton>
                             <RadioButton GroupName="rdoTaskbarMultiMonMode"
-                                         IsEnabled="{Binding Source={x:Static Settings:Settings.Instance}, Path=EnableTaskbarMultiMon, UpdateSourceTrigger=PropertyChanged}"
+                                         IsEnabled="{Binding Path=EnableTaskbarMultiMon, UpdateSourceTrigger=PropertyChanged}"
                                          Name="radTaskbarMultiMonMode1"
                                          Click="radTaskbarMultiMonMode1_Click">
                                 <Label Content="{Binding Path=(l10n:DisplayString.sSettings_Taskbar_MultiMonMode_PerMonitor)}" />
                             </RadioButton>
                             <RadioButton GroupName="rdoTaskbarMultiMonMode"
-                                         IsEnabled="{Binding Source={x:Static Settings:Settings.Instance}, Path=EnableTaskbarMultiMon, UpdateSourceTrigger=PropertyChanged}"
+                                         IsEnabled="{Binding Path=EnableTaskbarMultiMon, UpdateSourceTrigger=PropertyChanged}"
                                          Name="radTaskbarMultiMonMode2"
                                          Click="radTaskbarMultiMonMode2_Click">
                                 <Label Content="{Binding Path=(l10n:DisplayString.sSettings_Taskbar_MultiMonMode_Primary)}" />
@@ -872,7 +871,7 @@
                                   IsDropDownOpen="False"
                                   IsEditable="False"
                                   Width="109"
-                                  SelectedValue="{Binding Source={x:Static Settings:Settings.Instance}, Path=LogSeverity, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource enumStringConverter}}" />
+                                  SelectedValue="{Binding Path=LogSeverity, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource enumStringConverter}}" />
                         <Button Height="24"
                                 Padding="10,0"
                                 Margin="5,0,0,0"
@@ -889,7 +888,6 @@
                                  ToolTip="{Binding Path=(l10n:DisplayString.sSettings_General_TimeFormatTooltip)}">
                             <TextBox.Text>
                                 <Binding Path="TimeFormat"
-                                         Source="{x:Static Settings:Settings.Instance}"
                                          UpdateSourceTrigger="PropertyChanged">
                                     <Binding.ValidationRules>
                                         <supportingClasses:DateTimeFormatValidationRule />
@@ -904,7 +902,6 @@
                                  ToolTip="{Binding Path=(l10n:DisplayString.sSettings_General_DateFormatTooltip)}">
                             <TextBox.Text>
                                 <Binding Path="DateFormat"
-                                         Source="{x:Static Settings:Settings.Instance}"
                                          UpdateSourceTrigger="PropertyChanged">
                                     <Binding.ValidationRules>
                                         <supportingClasses:DateTimeFormatValidationRule />
@@ -919,7 +916,6 @@
                                  Width="50">
                             <TextBox.Text>
                                 <Binding Path="AutoHideShowDelayMs"
-                                         Source="{x:Static Settings:Settings.Instance}"
                                          UpdateSourceTrigger="PropertyChanged">
                                     <Binding.ValidationRules>
                                         <supportingClasses:IntegerValidationRule />
@@ -928,7 +924,7 @@
                             </TextBox.Text>
                         </TextBox>
                     </StackPanel>
-                    <CheckBox IsChecked="{Binding Source={x:Static Settings:Settings.Instance}, Path=ForceSoftwareRendering, UpdateSourceTrigger=PropertyChanged}"
+                    <CheckBox IsChecked="{Binding Path=ForceSoftwareRendering, UpdateSourceTrigger=PropertyChanged}"
                               Click="CheckBox_Click"
                               Name="chkForceSoftwareRendering">
                         <Label Content="{Binding Path=(l10n:DisplayString.sSettings_General_ForceSoftwareRendering)}" />
@@ -940,7 +936,6 @@
                         <TextBox Name="fileManager">
                             <TextBox.Text>
                                 <Binding Path="FileManager"
-                                         Source="{x:Static Settings:Settings.Instance}"
                                          UpdateSourceTrigger="PropertyChanged">
                                     <Binding.ValidationRules>
                                         <supportingClasses:FilePathValidationRule RequireFileExists="True" />

--- a/Cairo Desktop/Cairo Desktop/SettingsUI.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/SettingsUI.xaml.cs
@@ -39,6 +39,7 @@ namespace CairoDesktop
         private readonly ShellManager _shellManager;
         private readonly IThemeService _themeService;
         private readonly SettingsUIService _uiService;
+        private readonly Settings _settings;
 
         internal SettingsUI(ICairoApplication cairoApplication,
             SettingsUIService uiService,
@@ -46,7 +47,8 @@ namespace CairoDesktop
             IApplicationUpdateService applicationUpdateService,
             IAppGrabber appGrabber,
             IThemeService themeService,
-            ICommandService commandService)
+            ICommandService commandService,
+            Settings settings)
         {
             InitializeComponent();
 
@@ -57,6 +59,9 @@ namespace CairoDesktop
             _shellManager = shellManagerService.ShellManager;
             _themeService = themeService;
             _uiService = uiService;
+            _settings = settings;
+
+            DataContext = _settings;
 
             loadThemes();
             loadLanguages();
@@ -73,7 +78,7 @@ namespace CairoDesktop
             checkRunAtLogOn();
             checkIfCanHibernate();
 
-            Settings.Instance.PropertyChanged += Settings_PropertyChanged;
+            _settings.PropertyChanged += Settings_PropertyChanged;
             _commandService = commandService;
         }
 
@@ -99,7 +104,7 @@ namespace CairoDesktop
 
         private void loadRadioGroups()
         {
-            switch (Settings.Instance.DesktopLabelPosition)
+            switch (_settings.DesktopLabelPosition)
             {
                 case 0:
                     radDesktopLabelPos0.IsChecked = true;
@@ -113,7 +118,7 @@ namespace CairoDesktop
                     break;
             }
 
-            switch (Settings.Instance.DesktopIconSize)
+            switch (_settings.DesktopIconSize)
             {
                 case IconSize.Large:
                     radDesktopIconSize0.IsChecked = true;
@@ -127,7 +132,7 @@ namespace CairoDesktop
                     break;
             }
 
-            switch (Settings.Instance.MenuBarEdge)
+            switch (_settings.MenuBarEdge)
             {
                 case AppBarEdge.Top:
                     radMenuBarEdgeTop.IsChecked = true;
@@ -141,7 +146,7 @@ namespace CairoDesktop
                     break;
             }
 
-            switch (Settings.Instance.ProgramsMenuLayout)
+            switch (_settings.ProgramsMenuLayout)
             {
                 case 0:
                     radProgramsMenuLayout0.IsChecked = true;
@@ -155,7 +160,7 @@ namespace CairoDesktop
                     break;
             }
 
-            switch (Settings.Instance.TaskbarMode)
+            switch (_settings.TaskbarMode)
             {
                 case 0:
                     radTaskbarMode0.IsChecked = true;
@@ -176,7 +181,7 @@ namespace CairoDesktop
                     break;
             }
 
-            switch (Settings.Instance.TaskbarEdge)
+            switch (_settings.TaskbarEdge)
             {
                 case AppBarEdge.Bottom:
                     radTaskbarPosBottom.IsChecked = true;
@@ -190,7 +195,7 @@ namespace CairoDesktop
                     break;
             }
 
-            switch (Settings.Instance.TaskbarIconSize)
+            switch (_settings.TaskbarIconSize)
             {
                 case IconSize.Large:
                     radTaskbarSize0.IsChecked = true;
@@ -211,7 +216,7 @@ namespace CairoDesktop
                     break;
             }
 
-            switch (Settings.Instance.TaskbarMiddleClick)
+            switch (_settings.TaskbarMiddleClick)
             {
                 case 0:
                     radTaskbarMiddleClick0.IsChecked = true;
@@ -225,7 +230,7 @@ namespace CairoDesktop
                     break;
             }
 
-            switch (Settings.Instance.TaskbarGroupingStyle)
+            switch (_settings.TaskbarGroupingStyle)
             {
                 case 0:
                     radTaskbarGrouping0.IsChecked = true;
@@ -246,7 +251,7 @@ namespace CairoDesktop
                     break;
             }
 
-            switch (Settings.Instance.TaskbarMultiMonMode)
+            switch (_settings.TaskbarMultiMonMode)
             {
                 case 0:
                     radTaskbarMultiMonMode0.IsChecked = true;
@@ -267,7 +272,7 @@ namespace CairoDesktop
                     break;
             }
 
-            switch (Settings.Instance.SysTrayAlwaysExpanded)
+            switch (_settings.SysTrayAlwaysExpanded)
             {
                 case false:
                     radTrayMode0.IsChecked = true;
@@ -343,7 +348,7 @@ namespace CairoDesktop
 
         private void loadNotficationSettings()
         {
-            if (Settings.Instance.EnableSysTray)
+            if (_settings.EnableSysTray)
             {
                 PinnedIcons.ItemsSource = _shellManager.NotificationArea.PinnedIcons;
                 UnpinnedIcons.ItemsSource = _shellManager.NotificationArea.UnpinnedIcons;
@@ -419,7 +424,7 @@ namespace CairoDesktop
                 if (dropData.IsPinned)
                 {
                     dropData.Unpin();
-                    Settings.Instance.PinnedNotifyIcons = _shellManager.NotificationArea.PinnedNotifyIcons;
+                    _settings.PinnedNotifyIcons = _shellManager.NotificationArea.PinnedNotifyIcons;
                 }
             }
 
@@ -433,7 +438,7 @@ namespace CairoDesktop
                 NotifyIcon dropData = e.Data.GetData(typeof(NotifyIcon)) as NotifyIcon;
 
                 dropData.Pin();
-                Settings.Instance.PinnedNotifyIcons = _shellManager.NotificationArea.PinnedNotifyIcons;
+                _settings.PinnedNotifyIcons = _shellManager.NotificationArea.PinnedNotifyIcons;
             }
 
             e.Handled = true;
@@ -479,7 +484,7 @@ namespace CairoDesktop
                     dropData.Unpin();
                 }
 
-                Settings.Instance.PinnedNotifyIcons = _shellManager.NotificationArea.PinnedNotifyIcons;
+                _settings.PinnedNotifyIcons = _shellManager.NotificationArea.PinnedNotifyIcons;
             }
 
             e.Handled = true;
@@ -544,7 +549,7 @@ namespace CairoDesktop
 
         private void checkTrayStatus()
         {
-            if (!Settings.Instance.EnableTaskbar && !EnvironmentHelper.IsAppRunningAsShell)
+            if (!_settings.EnableTaskbar && !EnvironmentHelper.IsAppRunningAsShell)
             {
                 // if taskbar is disabled and we aren't running as shell, then Explorer tray is visible. Show warning.
                 lblTrayTaskbarWarning.Visibility = Visibility.Visible;
@@ -671,14 +676,14 @@ namespace CairoDesktop
             System.Windows.Forms.FolderBrowserDialog fbd = new System.Windows.Forms.FolderBrowserDialog();
             fbd.Description = Common.Localization.DisplayString.sDesktop_BrowseTitle;
             fbd.ShowNewFolderButton = false;
-            fbd.SelectedPath = Settings.Instance.DesktopDirectory;
+            fbd.SelectedPath = _settings.DesktopDirectory;
 
             if (fbd.ShowDialog() == System.Windows.Forms.DialogResult.OK)
             {
                 DirectoryInfo dir = new DirectoryInfo(fbd.SelectedPath);
                 if (dir != null)
                 {
-                    Settings.Instance.DesktopDirectory = fbd.SelectedPath;
+                    _settings.DesktopDirectory = fbd.SelectedPath;
                     txtDesktopHome.Text = fbd.SelectedPath;
                 }
             }
@@ -686,132 +691,132 @@ namespace CairoDesktop
 
         private void radMenuBarEdgeTop_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.MenuBarEdge = AppBarEdge.Top;
+            _settings.MenuBarEdge = AppBarEdge.Top;
         }
 
         private void radMenuBarEdgeBottom_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.MenuBarEdge = AppBarEdge.Bottom;
+            _settings.MenuBarEdge = AppBarEdge.Bottom;
         }
 
         private void radProgramsMenuLayout0_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.ProgramsMenuLayout = 0;
+            _settings.ProgramsMenuLayout = 0;
         }
 
         private void radProgramsMenuLayout1_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.ProgramsMenuLayout = 1;
+            _settings.ProgramsMenuLayout = 1;
         }
 
         private void radTaskbarMode0_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.TaskbarMode = 0;
+            _settings.TaskbarMode = 0;
         }
 
         private void radTaskbarMode1_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.TaskbarMode = 1;
+            _settings.TaskbarMode = 1;
         }
 
         private void radTaskbarMode2_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.TaskbarMode = 2;
+            _settings.TaskbarMode = 2;
         }
 
         private void radTaskbarPosBottom_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.TaskbarEdge = AppBarEdge.Bottom;
+            _settings.TaskbarEdge = AppBarEdge.Bottom;
         }
 
         private void radTaskbarPosTop_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.TaskbarEdge = AppBarEdge.Top;
+            _settings.TaskbarEdge = AppBarEdge.Top;
         }
 
         private void radTaskbarSize0_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.TaskbarIconSize = IconSize.Large;
+            _settings.TaskbarIconSize = IconSize.Large;
         }
 
         private void radTaskbarSize1_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.TaskbarIconSize = IconSize.Small;
+            _settings.TaskbarIconSize = IconSize.Small;
         }
 
         private void radTaskbarSize10_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.TaskbarIconSize = IconSize.Medium;
+            _settings.TaskbarIconSize = IconSize.Medium;
         }
 
         private void radTaskbarMiddleClick0_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.TaskbarMiddleClick = 0;
+            _settings.TaskbarMiddleClick = 0;
         }
 
         private void radTaskbarMiddleClick1_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.TaskbarMiddleClick = 1;
+            _settings.TaskbarMiddleClick = 1;
         }
 
         private void radTaskbarGrouping0_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.TaskbarGroupingStyle = 0;
+            _settings.TaskbarGroupingStyle = 0;
         }
 
         private void radTaskbarGrouping1_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.TaskbarGroupingStyle = 1;
+            _settings.TaskbarGroupingStyle = 1;
         }
 
         private void radTaskbarGrouping2_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.TaskbarGroupingStyle = 2;
+            _settings.TaskbarGroupingStyle = 2;
         }
 
         private void radTaskbarMultiMonMode0_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.TaskbarMultiMonMode = 0;
+            _settings.TaskbarMultiMonMode = 0;
         }
 
         private void radTaskbarMultiMonMode1_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.TaskbarMultiMonMode = 1;
+            _settings.TaskbarMultiMonMode = 1;
         }
 
         private void radTaskbarMultiMonMode2_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.TaskbarMultiMonMode = 2;
+            _settings.TaskbarMultiMonMode = 2;
         }
 
         private void radDesktopLabelPos0_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.DesktopLabelPosition = 0;
+            _settings.DesktopLabelPosition = 0;
         }
 
         private void radDesktopLabelPos1_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.DesktopLabelPosition = 1;
+            _settings.DesktopLabelPosition = 1;
         }
 
         private void radDesktopIconSize0_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.DesktopIconSize = IconSize.Large;
+            _settings.DesktopIconSize = IconSize.Large;
         }
 
         private void radDesktopIconSize2_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.DesktopIconSize = IconSize.ExtraLarge;
+            _settings.DesktopIconSize = IconSize.ExtraLarge;
         }
 
         private void radTrayMode0_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.SysTrayAlwaysExpanded = false;
+            _settings.SysTrayAlwaysExpanded = false;
         }
 
         private void radTrayMode1_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.SysTrayAlwaysExpanded = true;
+            _settings.SysTrayAlwaysExpanded = true;
         }
 
         private void cboCairoMenuHotKey_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -822,11 +827,11 @@ namespace CairoDesktop
             }
             string[] hotkey = { cboCairoMenuHotKeyMod1.SelectedValue.ToString(), cboCairoMenuHotKeyMod2.SelectedValue.ToString(), cboCairoMenuHotKeyKey.SelectedValue.ToString() };
 
-            if (Settings.Instance.CairoMenuHotKey[0] == hotkey[0] && Settings.Instance.CairoMenuHotKey[1] == hotkey[1] && Settings.Instance.CairoMenuHotKey[2] == hotkey[2])
+            if (_settings.CairoMenuHotKey[0] == hotkey[0] && _settings.CairoMenuHotKey[1] == hotkey[1] && _settings.CairoMenuHotKey[2] == hotkey[2])
             {
                 return;
             }
-            Settings.Instance.CairoMenuHotKey = hotkey;
+            _settings.CairoMenuHotKey = hotkey;
         }
 
         private void cboDesktopOverlayHotKey_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -837,11 +842,11 @@ namespace CairoDesktop
             }
             string[] hotkey = { cboDesktopOverlayHotKeyMod1.SelectedValue.ToString(), cboDesktopOverlayHotKeyMod2.SelectedValue.ToString(), cboDesktopOverlayHotKeyKey.SelectedValue.ToString() };
 
-            if (Settings.Instance.DesktopOverlayHotKey[0] == hotkey[0] && Settings.Instance.DesktopOverlayHotKey[1] == hotkey[1] && Settings.Instance.DesktopOverlayHotKey[2] == hotkey[2])
+            if (_settings.DesktopOverlayHotKey[0] == hotkey[0] && _settings.DesktopOverlayHotKey[1] == hotkey[1] && _settings.DesktopOverlayHotKey[2] == hotkey[2])
             {
                 return;
             }
-            Settings.Instance.DesktopOverlayHotKey = hotkey;
+            _settings.DesktopOverlayHotKey = hotkey;
         }
 
         private void btnChangeShell_Click(object sender, RoutedEventArgs e)
@@ -992,7 +997,7 @@ namespace CairoDesktop
                     };
                     cboCairoBackgroundStyle.Items.Add(cboImageItem);
 
-                    if (backgroundStyleItem == (Desktop.CairoWallpaperStyle)Settings.Instance.CairoBackgroundImageStyle) cboImageItem.IsSelected = true;
+                    if (backgroundStyleItem == (Desktop.CairoWallpaperStyle)_settings.CairoBackgroundImageStyle) cboImageItem.IsSelected = true;
 
                     // bing
                     ComboBoxItem cboBingItem = new ComboBoxItem()
@@ -1002,7 +1007,7 @@ namespace CairoDesktop
                     };
                     cboBingBackgroundStyle.Items.Add(cboBingItem);
 
-                    if (backgroundStyleItem == (Desktop.CairoWallpaperStyle)Settings.Instance.BingWallpaperStyle) cboBingItem.IsSelected = true;
+                    if (backgroundStyleItem == (Desktop.CairoWallpaperStyle)_settings.BingWallpaperStyle) cboBingItem.IsSelected = true;
                 }
             }
 
@@ -1016,7 +1021,7 @@ namespace CairoDesktop
                     Tag = cairoImageBackgroundStackPanel
                 };
                 cboDesktopBackgroundType.Items.Add(cairoImageWallpaperItem);
-                txtCairoBackgroundPath.Text = Settings.Instance.CairoBackgroundImagePath;
+                txtCairoBackgroundPath.Text = _settings.CairoBackgroundImagePath;
                 #endregion
 
                 #region  cairoVideoWallpaper
@@ -1027,7 +1032,7 @@ namespace CairoDesktop
                     Tag = cairoVideoBackgroundStackPanel
                 };
                 cboDesktopBackgroundType.Items.Add(cairoVideoWallpaperItem);
-                txtCairoVideoBackgroundPath.Text = Settings.Instance.CairoBackgroundVideoPath;
+                txtCairoVideoBackgroundPath.Text = _settings.CairoBackgroundVideoPath;
                 #endregion
 
                 #region  bingWallpaper
@@ -1041,7 +1046,7 @@ namespace CairoDesktop
                 #endregion
 
                 var listBoxItems = cboDesktopBackgroundType.Items.Cast<ComboBoxItem>().ToList();
-                var listBoxItem = listBoxItems.FirstOrDefault(l => l.Name == Settings.Instance.DesktopBackgroundType);
+                var listBoxItem = listBoxItems.FirstOrDefault(l => l.Name == _settings.DesktopBackgroundType);
 
                 cboDesktopBackgroundType.SelectedItem = listBoxItem;
             }
@@ -1079,7 +1084,7 @@ namespace CairoDesktop
                 if (dlg.SafeShowDialog() == System.Windows.Forms.DialogResult.OK)
                 {
                     txtCairoBackgroundPath.Text = dlg.FileName;
-                    Settings.Instance.CairoBackgroundImagePath = dlg.FileName;
+                    _settings.CairoBackgroundImagePath = dlg.FileName;
                 }
             }
         }
@@ -1118,7 +1123,7 @@ namespace CairoDesktop
                     }
 
                     txtCairoVideoBackgroundPath.Text = dlg.FileName;
-                    Settings.Instance.CairoBackgroundVideoPath = dlg.FileName;
+                    _settings.CairoBackgroundVideoPath = dlg.FileName;
                 }
             }
         }
@@ -1155,7 +1160,7 @@ namespace CairoDesktop
                 cairoVideoBackgroundStackPanel.Visibility = (item.Tag == cairoVideoBackgroundStackPanel) ? Visibility.Visible : Visibility.Collapsed;
                 bingImageBackgroundStackPanel.Visibility = (item.Tag == bingImageBackgroundStackPanel) ? Visibility.Visible : Visibility.Collapsed;
 
-                Settings.Instance.DesktopBackgroundType = item.Name;
+                _settings.DesktopBackgroundType = item.Name;
             }
         }
 
@@ -1213,8 +1218,8 @@ namespace CairoDesktop
             if (cboCairoBackgroundStyle.SelectedItem != null)
             {
                 int selected = (int)(cboCairoBackgroundStyle.SelectedItem as ComboBoxItem).Tag;
-                if (Settings.Instance.CairoBackgroundImageStyle != selected)
-                    Settings.Instance.CairoBackgroundImageStyle = selected;
+                if (_settings.CairoBackgroundImageStyle != selected)
+                    _settings.CairoBackgroundImageStyle = selected;
             }
         }
 
@@ -1223,7 +1228,7 @@ namespace CairoDesktop
             if (cboBingBackgroundStyle.SelectedItem != null)
             {
                 int selected = (int)(cboBingBackgroundStyle.SelectedItem as ComboBoxItem).Tag;
-                if (Settings.Instance.BingWallpaperStyle != selected) Settings.Instance.BingWallpaperStyle = selected;
+                if (_settings.BingWallpaperStyle != selected) _settings.BingWallpaperStyle = selected;
             }
         }
 

--- a/Cairo Desktop/Cairo Desktop/Welcome.xaml
+++ b/Cairo Desktop/Cairo Desktop/Welcome.xaml
@@ -35,7 +35,7 @@
                     <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
                         <TextBlock Style="{StaticResource WelcomeText}" Text="{Binding Path=(l10n:DisplayString.sWelcome_SelectLanguage)}" VerticalAlignment="Center" Margin="0,0,10,0" />
                         <ComboBox Name="cboLangSelect" DropDownClosed="cboLangSelect_DropDownClosed"  IsDropDownOpen="False" IsEditable="False" 
-                                  SelectedValue="{Binding Source={x:Static settings:Settings.Instance}, Path=Language, UpdateSourceTrigger=PropertyChanged}" />
+                                  SelectedValue="{Binding Path=Language, UpdateSourceTrigger=PropertyChanged}" />
                     </StackPanel>
                 </StackPanel>
             </DockPanel>

--- a/Cairo Desktop/Cairo Desktop/Welcome.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/Welcome.xaml.cs
@@ -16,16 +16,20 @@ namespace CairoDesktop
     {
         private readonly IAppGrabber _appGrabber;
         private readonly ICairoApplication _cairoApplication;
+        private readonly Settings _settings;
 
         const int maxSize = 780;
         string _initialLanguage = "en_US";
 
-        public Welcome(ICairoApplication cairoApplication, IAppGrabber appGrabber)
+        public Welcome(ICairoApplication cairoApplication, IAppGrabber appGrabber, Settings settings)
         {
             _appGrabber = appGrabber;
             _cairoApplication = cairoApplication;
+            _settings = settings;
 
             InitializeComponent();
+
+            cboLangSelect.DataContext = _settings;
 
             SetSizeAndLocation();
 
@@ -63,7 +67,7 @@ namespace CairoDesktop
 
         private void LoadLanguages()
         {
-            _initialLanguage = Settings.Instance.Language;
+            _initialLanguage = _settings.Language;
 
             cboLangSelect.DisplayMemberPath = "Key";
             cboLangSelect.SelectedValuePath = "Value";
@@ -73,7 +77,7 @@ namespace CairoDesktop
                 cboLangSelect.Items.Add(lang);
             }
 
-            cboLangSelect.SelectedValue = Settings.Instance.Language;
+            cboLangSelect.SelectedValue = _settings.Language;
         }
 
         private void btnGoPage2_Click(object sender, RoutedEventArgs e)
@@ -96,14 +100,14 @@ namespace CairoDesktop
 
         private void btnAppGrabber_Click(object sender, RoutedEventArgs e)
         {
-            Settings.Instance.IsFirstRun = false;
+            _settings.IsFirstRun = false;
             _appGrabber?.ShowDialog();
             Close();
         }
 
         private void cboLangSelect_DropDownClosed(object sender, EventArgs e)
         {
-            if (Settings.Instance.Language != _initialLanguage)
+            if (_settings.Language != _initialLanguage)
             {
                 CairoMessage.Show(DisplayString.sWelcome_ChangingLanguageText, DisplayString.sWelcome_ChangingLanguage, MessageBoxButton.OK, CairoMessageImage.Information,
                     result =>

--- a/Cairo Desktop/CairoDesktop.Infrastructure/Services/ShellManagerService.cs
+++ b/Cairo Desktop/CairoDesktop.Infrastructure/Services/ShellManagerService.cs
@@ -2,19 +2,22 @@
 using ManagedShell;
 using System;
 using System.ComponentModel;
-using ManagedShell.Common.Enums;
 
 namespace CairoDesktop.Infrastructure.Services
 {
     public class ShellManagerService : IDisposable
     {
+        private readonly Settings _settings;
+
         public ShellManager ShellManager { get; }
 
-        public ShellManagerService()
+        public ShellManagerService(Settings settings)
         {
+            _settings = settings;
+
             ShellManager = ConfigureShellManager();
 
-            Settings.Instance.PropertyChanged += Settings_PropertyChanged;
+            _settings.PropertyChanged += Settings_PropertyChanged;
         }
 
         private void Settings_PropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -25,7 +28,7 @@ namespace CairoDesktop.Infrastructure.Services
             switch (e.PropertyName)
             {
                 case "TaskbarIconSize":
-                    ShellManager.TasksService.TaskIconSize = (IconSize)Settings.Instance.TaskbarIconSize;
+                    ShellManager.TasksService.TaskIconSize = _settings.TaskbarIconSize;
                     break;
             }
         }
@@ -36,11 +39,11 @@ namespace CairoDesktop.Infrastructure.Services
             {
                 EnableTasksService = true,
                 AutoStartTasksService = false,
-                TaskIconSize = (IconSize)Settings.Instance.TaskbarIconSize,
+                TaskIconSize = _settings.TaskbarIconSize,
 
-                EnableTrayService = Settings.Instance.EnableSysTray,
+                EnableTrayService = _settings.EnableSysTray,
                 AutoStartTrayService = false,
-                PinnedNotifyIcons = Settings.Instance.PinnedNotifyIcons
+                PinnedNotifyIcons = _settings.PinnedNotifyIcons
             };
 
             return new ShellManager(config);

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/ActionCenterMenuBarExtension.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/ActionCenterMenuBarExtension.cs
@@ -8,9 +8,16 @@ namespace CairoDesktop.MenuBarExtensions
 {
     class ActionCenterMenuBarExtension : UserControlMenuBarExtension
     {
+        private readonly Settings _settings;
+
+        internal ActionCenterMenuBarExtension(Settings settings)
+        {
+            _settings = settings;
+        }
+
         public override UserControl StartControl(IMenuBar host)
         {
-            if (Settings.Instance.EnableMenuExtraActionCenter && EnvironmentHelper.IsWindows10OrBetter && !EnvironmentHelper.IsAppRunningAsShell)
+            if (_settings.EnableMenuExtraActionCenter && EnvironmentHelper.IsWindows10OrBetter && !EnvironmentHelper.IsAppRunningAsShell)
             {
                 return new ActionCenter(host);
             }

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/Clock.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/Clock.xaml.cs
@@ -5,21 +5,23 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Threading;
 using CairoDesktop.Application.Interfaces;
-using ManagedShell.Common.Helpers;
 
 namespace CairoDesktop.MenuBarExtensions
 {
     public partial class Clock : UserControl
     {
         private readonly ICommandService _commandService;
+        private readonly Settings _settings;
         private readonly bool _isPrimaryScreen;
         private static bool isClockHotkeyRegistered;
 
-        public Clock(IMenuBar host, ICommandService commandService)
+        public Clock(IMenuBar host, ICommandService commandService, Settings settings)
         {
             InitializeComponent();
 
             _commandService = commandService;
+            _settings = settings;
+
             _isPrimaryScreen = host.GetIsPrimaryDisplay();
 
             InitializeClock();
@@ -73,12 +75,12 @@ namespace CairoDesktop.MenuBarExtensions
 
         private void UpdateToolTip()
         {
-            dateText.ToolTip = DateTime.Now.ToString(Settings.Instance.DateFormat);
+            dateText.ToolTip = DateTime.Now.ToString(_settings.DateFormat);
         }
 
         private void UpdateText()
         {
-            dateText.Text = DateTime.Now.ToString(Settings.Instance.TimeFormat);
+            dateText.Text = DateTime.Now.ToString(_settings.TimeFormat);
         }
 
         private void OpenTimeDateCPL(object sender, RoutedEventArgs e)

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/ClockMenuBarExtension.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/ClockMenuBarExtension.cs
@@ -8,21 +8,23 @@ namespace CairoDesktop.MenuBarExtensions
     class ClockMenuBarExtension : UserControlMenuBarExtension
     {
         private readonly ICommandService _commandService;
+        private readonly Settings _settings;
         private Clock _clock;
 
-        internal ClockMenuBarExtension(ICommandService commandService)
+        internal ClockMenuBarExtension(ICommandService commandService, Settings settings)
         {
             _commandService = commandService;
+            _settings = settings;
         }
 
         public override UserControl StartControl(IMenuBar host)
         {
-            if (!Settings.Instance.EnableMenuExtraClock)
+            if (!_settings.EnableMenuExtraClock)
             {
                 return null;
             }
 
-            _clock = new Clock(host, _commandService);
+            _clock = new Clock(host, _commandService, _settings);
             return _clock;
         }
     }

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/MenuBarExtensionsShellExtension.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/MenuBarExtensionsShellExtension.cs
@@ -3,6 +3,7 @@ using CairoDesktop.Infrastructure.ExtensionMethods;
 using ManagedShell;
 using System.Collections.Generic;
 using CairoDesktop.Infrastructure.Services;
+using CairoDesktop.Common;
 
 namespace CairoDesktop.MenuBarExtensions
 {
@@ -10,25 +11,27 @@ namespace CairoDesktop.MenuBarExtensions
     {
         private readonly ICairoApplication _cairoApplication;
         private readonly ICommandService _commandService;
+        private readonly Settings _settings;
         private readonly ShellManager _shellManager;
 
         public List<IMenuBarExtension> MenuExtras { get; private set; }
 
-        public MenuBarExtensionsShellExtension(ICairoApplication cairoApplication, ShellManagerService shellManagerService, ICommandService commandService)
+        public MenuBarExtensionsShellExtension(ICairoApplication cairoApplication, ShellManagerService shellManagerService, ICommandService commandService, Settings settings)
         {
             _cairoApplication = cairoApplication;
             _commandService = commandService;
+            _settings = settings;
             _shellManager = shellManagerService.ShellManager;
             MenuExtras = new List<IMenuBarExtension>();
         }
 
         public void Start()
         {
-            MenuExtras.AddRange(new SystemTrayMenuBarExtension(_shellManager.NotificationArea),
-                                new VolumeMenuBarExtension(),
-                                new ActionCenterMenuBarExtension(),
-                                new ClockMenuBarExtension(_commandService),
-                                new SearchMenuBarExtension(_cairoApplication));
+            MenuExtras.AddRange(new SystemTrayMenuBarExtension(_shellManager.NotificationArea, _settings),
+                                new VolumeMenuBarExtension(_settings),
+                                new ActionCenterMenuBarExtension(_settings),
+                                new ClockMenuBarExtension(_commandService, _settings),
+                                new SearchMenuBarExtension(_cairoApplication, _settings));
 
             MenuExtras.AddTo(_cairoApplication.MenuBarExtensions);
         }

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/SearchMenuBarExtension.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/SearchMenuBarExtension.cs
@@ -8,16 +8,18 @@ namespace CairoDesktop.MenuBarExtensions
     class SearchMenuBarExtension : UserControlMenuBarExtension
     {
         private readonly ICairoApplication _cairoApplication;
+        private readonly Settings _settings;
         private Search _search;
 
-        internal SearchMenuBarExtension(ICairoApplication cairoApplication)
+        internal SearchMenuBarExtension(ICairoApplication cairoApplication, Settings settings)
         {
             _cairoApplication = cairoApplication;
+            _settings = settings;
         }
 
         public override UserControl StartControl(IMenuBar host)
         {
-            if (!Settings.Instance.EnableMenuExtraSearch) 
+            if (!_settings.EnableMenuExtraSearch) 
                 return null;
 
             _search = new Search(_cairoApplication, host);

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTray.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTray.xaml.cs
@@ -17,32 +17,34 @@ namespace CairoDesktop.MenuBarExtensions
     {
         private bool _isLoaded;
         private readonly NotificationArea _notificationArea;
+        private readonly Settings _settings;
 
         internal readonly IMenuBar Host;
 
         public ObservableCollection<NotifyIcon> PromotedIcons { get; private set; }
 
-        public SystemTray(IMenuBar host, NotificationArea notificationArea)
+        public SystemTray(IMenuBar host, NotificationArea notificationArea, Settings settings)
         {
             PromotedIcons = new ObservableCollection<NotifyIcon>();
 
             InitializeComponent();
             
             _notificationArea = notificationArea;
+            _settings = settings;
             DataContext = _notificationArea;
             Host = host;
 
             ((INotifyCollectionChanged)PinnedItems.Items).CollectionChanged += PinnedItems_CollectionChanged;
             ((INotifyCollectionChanged)UnpinnedItems.Items).CollectionChanged += UnpinnedItems_CollectionChanged;
 
-            if (Settings.Instance.SysTrayAlwaysExpanded)
+            if (_settings.SysTrayAlwaysExpanded)
             {
                 PromotedItems.Visibility = Visibility.Collapsed;
                 UnpinnedItems.Visibility = Visibility.Visible;
             }
 
             // Don't allow showing both the Windows TaskBar and the Cairo tray
-            if (Settings.Instance.EnableSysTray && (Settings.Instance.EnableTaskbar || EnvironmentHelper.IsAppRunningAsShell) && _notificationArea.Handle == IntPtr.Zero)
+            if (_settings.EnableSysTray && (_settings.EnableTaskbar || EnvironmentHelper.IsAppRunningAsShell) && _notificationArea.Handle == IntPtr.Zero)
             {
                 _notificationArea.Initialize();
             }
@@ -136,7 +138,7 @@ namespace CairoDesktop.MenuBarExtensions
 
         private void SetToggleVisibility()
         {
-            if (Settings.Instance.SysTrayAlwaysExpanded)
+            if (_settings.SysTrayAlwaysExpanded)
             {
                 return;
             }
@@ -180,7 +182,7 @@ namespace CairoDesktop.MenuBarExtensions
                 return;
             }
 
-            if (Settings.Instance.SysTrayAlwaysExpanded)
+            if (_settings.SysTrayAlwaysExpanded)
             {
                 btnToggle.Visibility = Visibility.Collapsed;
                 PromotedItems.Visibility = Visibility.Collapsed;
@@ -202,7 +204,7 @@ namespace CairoDesktop.MenuBarExtensions
                 return;
             }
 
-            Settings.Instance.PropertyChanged += Settings_PropertyChanged;
+            _settings.PropertyChanged += Settings_PropertyChanged;
             _notificationArea.NotificationBalloonShown += NotificationArea_NotificationBalloonShown;
 
             _isLoaded = true;
@@ -215,7 +217,7 @@ namespace CairoDesktop.MenuBarExtensions
                 return;
             }
 
-            Settings.Instance.PropertyChanged -= Settings_PropertyChanged;
+            _settings.PropertyChanged -= Settings_PropertyChanged;
             _notificationArea.NotificationBalloonShown -= NotificationArea_NotificationBalloonShown;
 
             _isLoaded = false;

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTrayMenuBarExtension.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTrayMenuBarExtension.cs
@@ -9,21 +9,23 @@ namespace CairoDesktop.MenuBarExtensions
     class SystemTrayMenuBarExtension : UserControlMenuBarExtension
     {
         private readonly NotificationArea _notificationArea;
+        private readonly Settings _settings;
         private SystemTray _systemTray;
 
-        internal SystemTrayMenuBarExtension(NotificationArea notificationArea)
+        internal SystemTrayMenuBarExtension(NotificationArea notificationArea, Settings settings)
         {
             _notificationArea = notificationArea;
+            _settings = settings;
         }
 
         public override UserControl StartControl(IMenuBar host)
         {
-            if (!Settings.Instance.EnableSysTray)
+            if (!_settings.EnableSysTray)
             {
                 return null;
             }
 
-            _systemTray = new SystemTray(host, _notificationArea);
+            _systemTray = new SystemTray(host, _notificationArea, _settings);
             return _systemTray;
         }
     }

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/VolumeMenuBarExtension.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/VolumeMenuBarExtension.cs
@@ -8,17 +8,21 @@ namespace CairoDesktop.MenuBarExtensions
 {
     class VolumeMenuBarExtension : UserControlMenuBarExtension
     {
+        private readonly Settings _settings;
         private Volume _volume;
+
+        internal VolumeMenuBarExtension(Settings settings)
+        {
+            _settings = settings;
+        }
 
         public override UserControl StartControl(IMenuBar host)
         {
-            if (Enabled)
+            if (!_settings.EnableMenuExtraVolume || !EnvironmentHelper.IsWindows10OrBetter || !EnvironmentHelper.IsAppRunningAsShell)
                 return null;
 
             _volume = new Volume();
             return _volume;
         }
-
-        private static bool Enabled => !Settings.Instance.EnableMenuExtraVolume || !EnvironmentHelper.IsWindows10OrBetter || !EnvironmentHelper.IsAppRunningAsShell;
     }
 }


### PR DESCRIPTION
- Changed direct references of `Settings.Instance` to use the injected `Settings` instance where readily available to do so
  - There are still a few direct references left that will become easier to change after future PRs.
- Simplified `SettingsUI` bindings by setting the `DataContext`
- Unrelated: Fixed mouse back/forward buttons navigating the desktop when the dynamic desktop is disabled.