### PR TITLE
Fix bottom programs menu closing itself (#824)

### DIFF
--- a/Cairo Desktop/CairoDesktop.MenuBar/Converters/ProgramsMenuHeightConverter.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBar/Converters/ProgramsMenuHeightConverter.cs
@@ -1,0 +1,26 @@
+﻿using CairoDesktop.Common;
+using System;
+using System.Windows.Data;
+
+namespace CairoDesktop.MenuBar.Converters
+{
+    [ValueConversion(typeof(void), typeof(double))]
+    public class ProgramsMenuHeightConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            if (Settings.Instance.MenuBarEdge == ManagedShell.AppBar.AppBarEdge.Bottom)
+            {
+                // To prevent the menu from moving from under the cursor while on bottom, set a constant height
+                return 400;
+            }
+
+            return double.NaN;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
+        {
+            return Binding.DoNothing;
+        }
+    }
+}

--- a/Cairo Desktop/CairoDesktop.MenuBar/ProgramsMenu.xaml
+++ b/Cairo Desktop/CairoDesktop.MenuBar/ProgramsMenu.xaml
@@ -3,9 +3,11 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:l10n="clr-namespace:CairoDesktop.Common.Localization;assembly=CairoDesktop.Common"
              xmlns:Settings="clr-namespace:CairoDesktop.Common;assembly=CairoDesktop.Common"
+             xmlns:converters="clr-namespace:CairoDesktop.MenuBar.Converters"
              Loaded="UserControl_Loaded">
     <UserControl.Resources>
         <ResourceDictionary>
+            <converters:ProgramsMenuHeightConverter x:Key="ProgramsMenuHeightConverter" />
             <Style x:Key="InnerProgramsListStyle"
                 TargetType="ItemsControl">
                 <Setter Property="ItemTemplate">
@@ -44,7 +46,7 @@
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="ItemsControl">
-                            <ScrollViewer CanContentScroll="True" HorizontalScrollBarVisibility="Disabled" MaxHeight="576" Width="240" VerticalScrollBarVisibility="Auto">
+                            <ScrollViewer CanContentScroll="True" HorizontalScrollBarVisibility="Disabled" MaxHeight="576" Width="240" Height="{Binding Converter={StaticResource ProgramsMenuHeightConverter}}" VerticalScrollBarVisibility="Auto">
                                 <VirtualizingStackPanel IsItemsHost="True" />
                             </ScrollViewer>
                         </ControlTemplate>


### PR DESCRIPTION
The programs menu normally changes its height depending on its contents. When the menu bar is on the bottom screen edge, and the menu shrinks due to selecting a smaller category, the clicked category moves out from under the cursor, causing the mouseup to occur outside of the menu, closing it.

Fixed the issue by making the programs menu a constant height when the menu bar is set to the bottom screen edge.