### PR TITLE
Misc App Grabber improvements

### DIFF
--- a/Cairo Desktop/Cairo Desktop/Program.cs
+++ b/Cairo Desktop/Cairo Desktop/Program.cs
@@ -18,6 +18,7 @@ using CairoDesktop.DynamicDesktop.Commands;
 using CairoDesktop.DynamicDesktop.Services;
 using CairoDesktop.MenuBar.Services;
 using CairoDesktop.Taskbar.Services;
+using CairoDesktop.AppGrabber.Commands;
 
 namespace CairoDesktop
 {
@@ -116,6 +117,8 @@ namespace CairoDesktop
                     services.AddSingleton<ICairoCommand, OpenPersonalizeControlPanelCommand>();
                     services.AddSingleton<ICairoCommand, OpenProgramsControlPanelCommand>();
                     services.AddSingleton<ICairoCommand, TaskViewCommand>();
+                    services.AddSingleton<ICairoCommand, AddToProgramsCommand>();
+                    services.AddSingleton<ICairoCommand, AddToQuickLaunchCommand>();
                 })
                 .ConfigureLogging((context, logging) =>
                 {

--- a/Cairo Desktop/CairoDesktop.AppGrabber/ApplicationInfo.cs
+++ b/Cairo Desktop/CairoDesktop.AppGrabber/ApplicationInfo.cs
@@ -266,8 +266,15 @@ namespace CairoDesktop.AppGrabber
 
                 return storeApp.GetIconImageSource(size);
             }
-            
-            return IconImageConverter.GetImageFromAssociatedIcon(Path, size);
+
+            IntPtr hIcon = IconHelper.GetIconByFilename(Path, size);
+            if (hIcon == IntPtr.Zero && Path.EndsWith(".lnk") && !string.IsNullOrEmpty(Target))
+            {
+                // Retry with target if this is a shortcut
+                hIcon = IconHelper.GetIconByFilename(Target, size);
+            }
+
+            return IconImageConverter.GetImageFromHIcon(hIcon);
         }
 
         public static ApplicationInfo FromStoreApp(ManagedShell.UWPInterop.StoreApp storeApp)

--- a/Cairo Desktop/CairoDesktop.AppGrabber/CairoDesktop.AppGrabber.csproj
+++ b/Cairo Desktop/CairoDesktop.AppGrabber/CairoDesktop.AppGrabber.csproj
@@ -8,7 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\CairoDesktop.Application\CairoDesktop.Application.csproj" />
     <ProjectReference Include="..\CairoDesktop.Common\CairoDesktop.Common.csproj" />
+    <ProjectReference Include="..\CairoDesktop.Infrastructure\CairoDesktop.Infrastructure.csproj" />
     <ProjectReference Include="..\CairoDesktop.Interop\CairoDesktop.Interop.csproj" />
   </ItemGroup>
 

--- a/Cairo Desktop/CairoDesktop.AppGrabber/CategoryList.cs
+++ b/Cairo Desktop/CairoDesktop.AppGrabber/CategoryList.cs
@@ -240,8 +240,9 @@ namespace CairoDesktop.AppGrabber {
                     if (appElement.ChildNodes.Count > 2)
                         app.Target = appElement.ChildNodes[2].InnerText;
 
-                    if (!app.IsStoreApp && !ShellHelper.Exists(app.Path)) {
-                        ShellLogger.Debug(app.Path + " does not exist");
+                    if (!app.IsStoreApp && !ShellHelper.Exists(app.Path) && (!app.Path.EndsWith(".lnk") || string.IsNullOrEmpty(app.Target) || !ShellHelper.Exists(app.Target)))
+                    {
+                        ShellLogger.Debug($"[AppGrabber] {app.Path} does not exist");
                         continue;
                     }
 

--- a/Cairo Desktop/CairoDesktop.AppGrabber/Commands/AddToProgramsCommand.cs
+++ b/Cairo Desktop/CairoDesktop.AppGrabber/Commands/AddToProgramsCommand.cs
@@ -1,0 +1,94 @@
+﻿using CairoDesktop.Application.Interfaces;
+using CairoDesktop.Application.Structs;
+using CairoDesktop.Common.Localization;
+using CairoDesktop.Infrastructure.ObjectModel;
+using ManagedShell.ShellFolders;
+using System.Collections.Generic;
+
+namespace CairoDesktop.AppGrabber.Commands
+{
+    public class AddToProgramsCommand : ICairoCommand
+    {
+        public ICairoCommandInfo Info => _info;
+
+        private readonly IAppGrabber _appGrabber;
+        private readonly AddToProgramsCommandInfo _info;
+
+        public AddToProgramsCommand(IAppGrabber appGrabber)
+        {
+            _appGrabber = appGrabber;
+            _info = new AddToProgramsCommandInfo(_appGrabber);
+        }
+
+        public bool Execute(params (string name, object value)[] parameters)
+        {
+            string path = "";
+
+            foreach (var parameter in parameters)
+            {
+                switch (parameter.name)
+                {
+                    case "Path":
+                        if (parameter.value is string _path)
+                        {
+                            path = _path;
+                        }
+                        break;
+                }
+            }
+
+            if (string.IsNullOrEmpty(path))
+            {
+                return false;
+            }
+
+            _appGrabber.AddByPath(path, AppCategoryType.Uncategorized);
+
+            return true;
+        }
+    }
+
+    public class AddToProgramsCommandInfo : ICairoShellItemCommandInfo
+    {
+        public string Identifier => "AddToPrograms";
+
+        public string Description => "Adds the specified application to the programs menu.";
+
+        public string Label => DisplayString.sCommand_AddToPrograms;
+
+        public bool IsAvailable => true;
+
+        private List<CairoCommandParameter> _parameters = new List<CairoCommandParameter>()
+        {
+            new CairoCommandParameter {
+                Name = "Path",
+                Description = "Application to add to the programs menu",
+                IsRequired = true
+            }
+        };
+
+        public IReadOnlyCollection<CairoCommandParameter> Parameters => _parameters;
+
+        private readonly IAppGrabber _appGrabber;
+
+        public AddToProgramsCommandInfo(IAppGrabber appGrabber)
+        {
+            _appGrabber = appGrabber;
+        }
+
+        public string LabelForShellItem(ShellItem item)
+        {
+            return Label;
+        }
+
+        public bool IsAvailableForShellItem(ShellItem item)
+        {
+            if (item.IsNavigableFolder)
+            {
+                return false;
+            }
+
+            return _appGrabber.CanAddPathToCategory(item.Path, AppCategoryType.All);
+        }
+    }
+}

--- a/Cairo Desktop/CairoDesktop.AppGrabber/Commands/AddToQuickLaunchCommand.cs
+++ b/Cairo Desktop/CairoDesktop.AppGrabber/Commands/AddToQuickLaunchCommand.cs
@@ -1,0 +1,94 @@
+﻿using CairoDesktop.Application.Interfaces;
+using CairoDesktop.Application.Structs;
+using CairoDesktop.Common.Localization;
+using CairoDesktop.Infrastructure.ObjectModel;
+using ManagedShell.ShellFolders;
+using System.Collections.Generic;
+
+namespace CairoDesktop.AppGrabber.Commands
+{
+    public class AddToQuickLaunchCommand : ICairoCommand
+    {
+        public ICairoCommandInfo Info => _info;
+
+        private readonly IAppGrabber _appGrabber;
+        private readonly AddToQuickLaunchCommandInfo _info;
+
+        public AddToQuickLaunchCommand(IAppGrabber appGrabber)
+        {
+            _appGrabber = appGrabber;
+            _info = new AddToQuickLaunchCommandInfo(_appGrabber);
+        }
+
+        public bool Execute(params (string name, object value)[] parameters)
+        {
+            string path = "";
+
+            foreach (var parameter in parameters)
+            {
+                switch (parameter.name)
+                {
+                    case "Path":
+                        if (parameter.value is string _path)
+                        {
+                            path = _path;
+                        }
+                        break;
+                }
+            }
+
+            if (string.IsNullOrEmpty(path))
+            {
+                return false;
+            }
+
+            _appGrabber.AddByPath(path, AppCategoryType.QuickLaunch);
+
+            return true;
+        }
+    }
+
+    public class AddToQuickLaunchCommandInfo : ICairoShellItemCommandInfo
+    {
+        public string Identifier => "AddToQuickLaunch";
+
+        public string Description => "Adds the specified application to quick launch.";
+
+        public string Label => DisplayString.sCommand_AddToQuickLaunch;
+
+        public bool IsAvailable => true;
+
+        private List<CairoCommandParameter> _parameters = new List<CairoCommandParameter>()
+        {
+            new CairoCommandParameter {
+                Name = "Path",
+                Description = "Application to add to quick launch",
+                IsRequired = true
+            }
+        };
+
+        public IReadOnlyCollection<CairoCommandParameter> Parameters => _parameters;
+
+        private readonly IAppGrabber _appGrabber;
+
+        public AddToQuickLaunchCommandInfo(IAppGrabber appGrabber)
+        {
+            _appGrabber = appGrabber;
+        }
+
+        public string LabelForShellItem(ShellItem item)
+        {
+            return Label;
+        }
+
+        public bool IsAvailableForShellItem(ShellItem item)
+        {
+            if (item.IsNavigableFolder)
+            {
+                return false;
+            }
+
+            return _appGrabber.CanAddPathToCategory(item.Path, AppCategoryType.QuickLaunch);
+        }
+    }
+}

--- a/Cairo Desktop/CairoDesktop.Common/Icon.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.Common/Icon.xaml.cs
@@ -370,7 +370,7 @@ namespace CairoDesktop.Common
                             DragDrop.DoDragDrop(button, dragObject,
                                 (e.RightButton == MouseButtonState.Pressed
                                     ? DragDropEffects.All
-                                    : DragDropEffects.Move));
+                                    : DragDropEffects.Move) | DragDropEffects.Link);
                         }
                         catch (Exception exception)
                         {

--- a/Cairo Desktop/CairoDesktop.Common/Localization/DisplayString.cs
+++ b/Cairo Desktop/CairoDesktop.Common/Localization/DisplayString.cs
@@ -710,5 +710,9 @@ namespace CairoDesktop.Common.Localization
         public static string sCommand_OpenDesktopOverlay => getString();
 
         public static string sCommand_CloseDesktopOverlay => getString();
+
+        public static string sCommand_AddToPrograms => getString();
+
+        public static string sCommand_AddToQuickLaunch => getString();
     }
 }

--- a/Cairo Desktop/CairoDesktop.Common/Localization/Language.cs
+++ b/Cairo Desktop/CairoDesktop.Common/Localization/Language.cs
@@ -305,6 +305,8 @@ namespace CairoDesktop.Common.Localization
             { "sCommand_OpenLocation", "Open Location" },
             { "sCommand_OpenDesktopOverlay", "Open Desktop Overlay" },
             { "sCommand_CloseDesktopOverlay", "Close Desktop Overlay" },
+            { "sCommand_AddToPrograms", "Add to programs menu" },
+            { "sCommand_AddToQuickLaunch", "Add to quick launch" },
         };
 
         public static Dictionary<string, string> pt_BR = new Dictionary<string, string>


### PR DESCRIPTION
- Added "add to programs menu" and "add to quick launch" commands to the shell context menu
- If a shortcut that was added has been deleted but the target still exists, use the target where possible
  - This is useful if you "add to programs" a shortcut from your desktop, then delete it from your desktop
- Fixed being unable to drag desktop icons to the programs menu
- Adding exe files without a file description no longer throws an error