### PR TITLE
Fix autorun setting on .NET 6

### DIFF
--- a/Cairo Desktop/Cairo Desktop/SettingsUI.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/SettingsUI.xaml.cs
@@ -884,7 +884,7 @@ namespace CairoDesktop
                 }
                 else
                 {
-                    string exePath = System.Reflection.Assembly.GetExecutingAssembly().Location;
+                    string exePath = ExePath.GetExecutablePath();
                     //Write SubKey
                     rKey.SetValue("CairoShell", exePath);
                 }

--- a/Cairo Desktop/Cairo Desktop/SupportingClasses/ExePath.cs
+++ b/Cairo Desktop/Cairo Desktop/SupportingClasses/ExePath.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Text;
+
+namespace CairoDesktop.SupportingClasses
+{
+    class ExePath
+    {
+        [System.Runtime.InteropServices.DllImport("kernel32.dll")]
+        static extern uint GetModuleFileName(IntPtr hModule, StringBuilder lpFilename, int nSize);
+        static readonly int MAX_PATH = 260;
+
+        internal static string GetExecutablePath()
+        {
+            var sb = new StringBuilder(MAX_PATH);
+            GetModuleFileName(IntPtr.Zero, sb, MAX_PATH);
+            return sb.ToString();
+        }
+    }
+}


### PR DESCRIPTION
Otherwise we get the DLL instead of the EXE.

Fixes #857 