### PR TITLE
Update ManagedShell, improve logger

### DIFF
--- a/Cairo Desktop/Cairo Desktop/Cairo Desktop.csproj
+++ b/Cairo Desktop/Cairo Desktop/Cairo Desktop.csproj
@@ -65,7 +65,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedShell" Version="0.0.264" />
+    <PackageReference Include="ManagedShell" Version="0.0.270" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/Cairo Desktop/CairoDesktop.Common/CairoDesktop.Common.csproj
+++ b/Cairo Desktop/CairoDesktop.Common/CairoDesktop.Common.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedShell" Version="0.0.264" />
+    <PackageReference Include="ManagedShell" Version="0.0.270" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />


### PR DESCRIPTION
Updates ManagedShell to fix #398 and other issues

Improved ManagedShellLoggerProvider to not crash in the case the file could not be created, and moved it away from using Debug.WriteLine now that we have log flushing