### PR TITLE
Fix unable to restore default file manager

### DIFF
--- a/Cairo Desktop/Cairo Desktop/SupportingClasses/FilePathValidationRule.cs
+++ b/Cairo Desktop/Cairo Desktop/SupportingClasses/FilePathValidationRule.cs
@@ -25,6 +25,8 @@ namespace CairoDesktop.SupportingClasses
                         return new ValidationResult(false, "Path is Blank");
                     }
 
+                    stringValue = Environment.ExpandEnvironmentVariables(stringValue);
+
                     if (CheckPathLength)
                     {
                         try
@@ -41,8 +43,7 @@ namespace CairoDesktop.SupportingClasses
                     // Check for Invalid Path Chars.
                     if (CheckInvalidPathChars)
                     {
-                        if (Path.GetDirectoryName(stringValue).Any(Path.GetInvalidPathChars().Contains) && // TODO: Should invalid chars in dir and filename be an OR?
-                            Path.GetFileName(stringValue).Any(Path.GetInvalidPathChars().Contains))
+                        if (stringValue.Any(Path.GetInvalidPathChars().Contains))
                         {
                             return new ValidationResult(false, "Invalid Path Chars.");
                         }


### PR DESCRIPTION
The settings window was marking the default value as invalid. The validator wasn't expanding environment variables, which the default setting contains.