### PR TITLE
Fix App Grabber size on secondary display

### DIFF
--- a/Cairo Desktop/CairoDesktop.AppGrabber/AppGrabberUI.xaml
+++ b/Cairo Desktop/CairoDesktop.AppGrabber/AppGrabberUI.xaml
@@ -10,6 +10,7 @@
         Background="Transparent"
         WindowStartupLocation="CenterScreen" 
         UseLayoutRounding="True" 
+        SourceInitialized="Window_SourceInitialized"
         ContentRendered="Window_ContentRendered"
         Closing="Window_Closing">
     <Window.Resources>

--- a/Cairo Desktop/CairoDesktop.AppGrabber/AppGrabberUI.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.AppGrabber/AppGrabberUI.xaml.cs
@@ -9,7 +9,7 @@ using System.Windows.Forms;
 using ManagedShell.Common.Helpers;
 using ManagedShell.Common.Logging;
 using System.Windows.Interop;
-using System.Drawing;
+using System.Windows.Media;
 
 namespace CairoDesktop.AppGrabber
 {
@@ -65,15 +65,12 @@ namespace CairoDesktop.AppGrabber
             WindowInteropHelper helper = new WindowInteropHelper(this);
 
             Screen screen = Screen.FromHandle(helper.Handle);
-            double dpiScale = 1.0;
-            using (Graphics g = Graphics.FromHwnd(helper.Handle))
-            {
-                dpiScale = g.DpiX / 96;
-            }
+            DpiScale dpiScale = VisualTreeHelper.GetDpi(this);
 
-            MaxHeight = screen.WorkingArea.Height / dpiScale;
+            MaxHeight = screen.WorkingArea.Height / dpiScale.DpiScaleY;
             Height = MaxHeight - 100;
-            Top = (screen.WorkingArea.Top / dpiScale) + ((MaxHeight - Height) / 2);
+            Top = (screen.WorkingArea.Top / dpiScale.DpiScaleY) + ((MaxHeight - Height) / 2);
+            Left = (screen.WorkingArea.Left / dpiScale.DpiScaleX) + (((screen.WorkingArea.Width / dpiScale.DpiScaleX) - Width) / 2);
         }
 
         #region Button Clicks

--- a/Cairo Desktop/CairoDesktop.AppGrabber/AppGrabberUI.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.AppGrabber/AppGrabberUI.xaml.cs
@@ -8,6 +8,8 @@ using System.Windows.Controls;
 using System.Windows.Forms;
 using ManagedShell.Common.Helpers;
 using ManagedShell.Common.Logging;
+using System.Windows.Interop;
+using System.Drawing;
 
 namespace CairoDesktop.AppGrabber
 {
@@ -56,9 +58,22 @@ namespace CairoDesktop.AppGrabber
         {
             this.appGrabber = appGrabber;
             InitializeComponent();
+        }
 
-            Height = (SystemParameters.MaximizedPrimaryScreenHeight / DpiHelper.DpiScaleAdjustment) - 100;
-            MaxHeight = SystemParameters.MaximizedPrimaryScreenHeight / DpiHelper.DpiScaleAdjustment;
+        private void Window_SourceInitialized(object sender, EventArgs e)
+        {
+            WindowInteropHelper helper = new WindowInteropHelper(this);
+
+            Screen screen = Screen.FromHandle(helper.Handle);
+            double dpiScale = 1.0;
+            using (Graphics g = Graphics.FromHwnd(helper.Handle))
+            {
+                dpiScale = g.DpiX / 96;
+            }
+
+            MaxHeight = screen.WorkingArea.Height / dpiScale;
+            Height = MaxHeight - 100;
+            Top = (screen.WorkingArea.Top / dpiScale) + ((MaxHeight - Height) / 2);
         }
 
         #region Button Clicks

--- a/Cairo Desktop/CairoDesktop.AppGrabber/Commands/OpenAppGrabberCommand.cs
+++ b/Cairo Desktop/CairoDesktop.AppGrabber/Commands/OpenAppGrabberCommand.cs
@@ -1,10 +1,9 @@
-﻿using CairoDesktop.AppGrabber;
-using CairoDesktop.Application.Interfaces;
+﻿using CairoDesktop.Application.Interfaces;
 using CairoDesktop.Application.Structs;
 using CairoDesktop.Common.Localization;
 using System.Collections.Generic;
 
-namespace CairoDesktop.Commands
+namespace CairoDesktop.AppGrabber.Commands
 {
     public class OpenAppGrabberCommand : ICairoCommand
     {


### PR DESCRIPTION
When opening the App Grabber from a menu bar on a non-primary display, the size was being set incorrectly based on the primary display instead.