### PR TITLE
Allow disabling the WinKey when shell

### DIFF
--- a/Cairo Desktop/Cairo Desktop/SettingsUI.xaml
+++ b/Cairo Desktop/Cairo Desktop/SettingsUI.xaml
@@ -361,6 +361,11 @@
                                   SelectionChanged="cboCairoMenuHotKey_OnSelectionChanged"
                                   SelectedValue="{Binding Mode=OneWay, Path=CairoMenuHotKey[2], UpdateSourceTrigger=PropertyChanged}" />
                     </StackPanel>
+                    <CheckBox IsChecked="{Binding Path=EnableWinKey, UpdateSourceTrigger=PropertyChanged}"
+                              Name="chkEnableWinKey"
+                              Visibility="Collapsed">
+                        <Label Content="{Binding Path=(l10n:DisplayString.sSettings_MenuBar_EnableWinKey)}" />
+                    </CheckBox>
                     <CheckBox IsChecked="{Binding Path=ShowHibernate, UpdateSourceTrigger=PropertyChanged}"
                               Name="chkShowHibernate">
                         <Label Content="{Binding Path=(l10n:DisplayString.sSettings_MenuBar_ShowHibernate)}" />

--- a/Cairo Desktop/Cairo Desktop/SettingsUI.xaml.cs
+++ b/Cairo Desktop/Cairo Desktop/SettingsUI.xaml.cs
@@ -71,6 +71,7 @@ namespace CairoDesktop
             loadHotKeys();
             loadLoggingLevels();
             loadNotificationSettings();
+            loadShellDependentSettings();
             loadVersionDependentSettings();
 
             checkUpdateConfig();
@@ -374,6 +375,14 @@ namespace CairoDesktop
             else if (EnvironmentHelper.IsWindows10OrBetter && EnvironmentHelper.IsAppRunningAsShell)
             {
                 chkEnableMenuExtraActionCenter.Visibility = Visibility.Collapsed;
+            }
+        }
+
+        private void loadShellDependentSettings()
+        {
+            if (EnvironmentHelper.IsAppRunningAsShell)
+            {
+                chkEnableWinKey.Visibility = Visibility.Visible;
             }
         }
 

--- a/Cairo Desktop/CairoDesktop.Common/Localization/DisplayString.cs
+++ b/Cairo Desktop/CairoDesktop.Common/Localization/DisplayString.cs
@@ -492,6 +492,8 @@ namespace CairoDesktop.Common.Localization
 
         public static string sSettings_MenuBar_EnableCairoMenuHotKey => getString();
 
+        public static string sSettings_MenuBar_EnableWinKey => getString();
+
         public static string sSettings_MenuBar_EnableMenuBarBlur => getString();
 
         public static string sSettings_MenuBar_EnableMenuBarMultiMon => getString();

--- a/Cairo Desktop/CairoDesktop.Common/Localization/Language.cs
+++ b/Cairo Desktop/CairoDesktop.Common/Localization/Language.cs
@@ -194,6 +194,7 @@ namespace CairoDesktop.Common.Localization
             { "sSettings_MenuBar_PinnedIcons", "Pinned icons:" },
             { "sSettings_MenuBar_NotificationAreaPinHelp", "To pin a notification area icon, drag it to the pinned icons area. To unpin an icon, drag it to the collapsible icons area." },
             { "sSettings_MenuBar_EnableCairoMenuHotKey", "Enable Cairo menu hotkey:" },
+            { "sSettings_MenuBar_EnableWinKey", "Open the Programs menu with the Windows key" },
             { "sSettings_MenuBar_EnableMenuBarBlur", "Blur behind the menu bar" },
             { "sSettings_MenuBar_EnableMenuBarMultiMon", "Show menu bar on multiple monitors" },
             { "sSettings_MenuBar_ShowHibernate", "Show Hibernate option in the Cairo menu" },

--- a/Cairo Desktop/CairoDesktop.Common/Settings.cs
+++ b/Cairo Desktop/CairoDesktop.Common/Settings.cs
@@ -530,6 +530,13 @@ namespace CairoDesktop.Common
             get => _showStacksRemovableDrives;
             set => Set(ref _showStacksRemovableDrives, value);
         }
+
+        private bool _enableWinKey = true;
+        public bool EnableWinKey
+        {
+            get => _enableWinKey;
+            set => Set(ref _enableWinKey, value);
+        }
         #endregion
 
         #region Advanced

--- a/Cairo Desktop/CairoDesktop.MenuBar/MenuBar.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBar/MenuBar.xaml.cs
@@ -303,27 +303,7 @@ namespace CairoDesktop.MenuBar
             SetupMenuBarExtensions();
 
             registerCairoMenuHotKey();
-
-            // Register L+R Windows key to open Programs menu
-            if (EnvironmentHelper.IsAppRunningAsShell && Screen.Primary && programsMenuHotKeys.Count < 1)
-            {
-                /*if (keyboardListener == null)
-                    keyboardListener = new LowLevelKeyboardListener();
-
-                keyboardListener.OnKeyPressed += keyboardListener_OnKeyPressed;
-                keyboardListener.HookKeyboard();*/
-
-                programsMenuHotKeys.Add(new HotKey(Key.LWin, HotKeyModifier.Win | HotKeyModifier.NoRepeat, OnShowProgramsMenu));
-                programsMenuHotKeys.Add(new HotKey(Key.RWin, HotKeyModifier.Win | HotKeyModifier.NoRepeat, OnShowProgramsMenu));
-                programsMenuHotKeys.Add(new HotKey(Key.Escape, HotKeyModifier.Ctrl | HotKeyModifier.NoRepeat, OnShowProgramsMenu));
-            }
-            else if (EnvironmentHelper.IsAppRunningAsShell && Screen.Primary)
-            {
-                foreach (var hotkey in programsMenuHotKeys)
-                {
-                    hotkey.Action = OnShowProgramsMenu;
-                }
-            }
+            registerWinKey();
 
             SetBlur(_settings.EnableMenuBarBlur);
 
@@ -349,6 +329,51 @@ namespace CairoDesktop.MenuBar
                 cairoMenuHotKey?.Dispose();
                 cairoMenuHotKey = null;
             }
+        }
+
+        private void registerWinKey()
+        {
+            if (!EnvironmentHelper.IsAppRunningAsShell || !Screen.Primary || !_settings.EnableWinKey)
+            {
+                return;
+            }
+
+            // Register L+R Windows key to open Programs menu
+            if (programsMenuHotKeys.Count < 1)
+            {
+                /*if (keyboardListener == null)
+                    keyboardListener = new LowLevelKeyboardListener();
+
+                keyboardListener.OnKeyPressed += keyboardListener_OnKeyPressed;
+                keyboardListener.HookKeyboard();*/
+
+                programsMenuHotKeys.Add(new HotKey(Key.LWin, HotKeyModifier.Win | HotKeyModifier.NoRepeat, OnShowProgramsMenu));
+                programsMenuHotKeys.Add(new HotKey(Key.RWin, HotKeyModifier.Win | HotKeyModifier.NoRepeat, OnShowProgramsMenu));
+                programsMenuHotKeys.Add(new HotKey(Key.Escape, HotKeyModifier.Ctrl | HotKeyModifier.NoRepeat, OnShowProgramsMenu));
+            }
+            else
+            {
+                // We replaced another primary monitor instance, register our handler instead
+                foreach (var hotkey in programsMenuHotKeys)
+                {
+                    hotkey.Action = OnShowProgramsMenu;
+                }
+            }
+        }
+
+        private void unregisterWinKey()
+        {
+            if (!Screen.Primary)
+            {
+                return;
+            }
+
+            foreach (var hotkey in programsMenuHotKeys)
+            {
+                hotkey.Unregister();
+            }
+
+            programsMenuHotKeys.Clear();
         }
 
         #region Programs menu
@@ -530,6 +555,16 @@ namespace CairoDesktop.MenuBar
                             registerCairoMenuHotKey();
                         }
 
+                        break;
+                    case "EnableWinKey":
+                        if (_settings.EnableWinKey)
+                        {
+                            registerWinKey();
+                        }
+                        else
+                        {
+                            unregisterWinKey();
+                        }
                         break;
                     case "EnableMenuBarBlur":
                         SetBlur(_settings.EnableMenuBarBlur);


### PR DESCRIPTION
Our WinKey handling prevents other WinKey shortcuts throughout the system from working properly. Allow users to disable it if they want to.

Fixes #713