### PR TITLE
Fix leaks causing menu bar, taskbar, and desktop instances to be retained in memory

### DIFF
--- a/Cairo Desktop/Cairo Desktop/Cairo Desktop.csproj
+++ b/Cairo Desktop/Cairo Desktop/Cairo Desktop.csproj
@@ -65,7 +65,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedShell" Version="0.0.320" />
+    <PackageReference Include="ManagedShell" Version="0.0.330" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/Cairo Desktop/CairoDesktop.AppGrabber/CategoryList.cs
+++ b/Cairo Desktop/CairoDesktop.AppGrabber/CategoryList.cs
@@ -105,7 +105,7 @@ namespace CairoDesktop.AppGrabber {
 
         private void Category_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
         {
-            OnCategoryChanged(new EventArgs());
+            OnCategoryChanged(sender, new EventArgs());
         }
 
         /// <summary>
@@ -276,9 +276,9 @@ namespace CairoDesktop.AppGrabber {
             return catList;
         }
 
-        protected virtual void OnCategoryChanged(EventArgs e)
+        protected virtual void OnCategoryChanged(object sender, EventArgs e)
         {
-            CategoryChanged?.Invoke(this, e);
+            CategoryChanged?.Invoke(sender, e);
         }
     }
 }

--- a/Cairo Desktop/CairoDesktop.Common/CairoDesktop.Common.csproj
+++ b/Cairo Desktop/CairoDesktop.Common/CairoDesktop.Common.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedShell" Version="0.0.320" />
+    <PackageReference Include="ManagedShell" Version="0.0.330" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />

--- a/Cairo Desktop/CairoDesktop.Common/NavigationManager.cs
+++ b/Cairo Desktop/CairoDesktop.Common/NavigationManager.cs
@@ -7,7 +7,7 @@ using ManagedShell.ShellFolders;
 
 namespace CairoDesktop.Common
 {
-    public class NavigationManager : INotifyPropertyChanged
+    public class NavigationManager : INotifyPropertyChanged, IDisposable
     {
         private List<NavigationItem> list;
         private int _currentIndex;
@@ -39,6 +39,11 @@ namespace CairoDesktop.Common
             Settings.Instance.PropertyChanged += Settings_PropertyChanged;
 
             NavigateHome();
+        }
+
+        public void Dispose()
+        {
+            Settings.Instance.PropertyChanged -= Settings_PropertyChanged;
         }
 
         private void Settings_PropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Cairo Desktop/CairoDesktop.DynamicDesktop/DesktopIcons.xaml
+++ b/Cairo Desktop/CairoDesktop.DynamicDesktop/DesktopIcons.xaml
@@ -3,7 +3,8 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:common="clr-namespace:CairoDesktop.Common;assembly=CairoDesktop.Common"
-             UseLayoutRounding="True">
+             UseLayoutRounding="True"
+             Unloaded="UserControl_Unloaded">
     <DockPanel Name="panel" Margin="0">
         <ItemsControl Name="IconsControl" 
                       Style="{StaticResource DesktopFolderViewStyle}" 

--- a/Cairo Desktop/CairoDesktop.DynamicDesktop/DesktopIcons.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.DynamicDesktop/DesktopIcons.xaml.cs
@@ -366,5 +366,10 @@ namespace CairoDesktop.DynamicDesktop
                     break;
             }
         }
+
+        private void UserControl_Unloaded(object sender, RoutedEventArgs e)
+        {
+            _settings.PropertyChanged -= Settings_PropertyChanged;
+        }
     }
 }

--- a/Cairo Desktop/CairoDesktop.DynamicDesktop/Services/DesktopManager.cs
+++ b/Cairo Desktop/CairoDesktop.DynamicDesktop/Services/DesktopManager.cs
@@ -149,7 +149,12 @@ namespace CairoDesktop.DynamicDesktop.Services
             DesktopOverlayWindow?.Close();
             DesktopOverlayWindow = null;
             DestroyToolbar();
-            NavigationManager = null;
+            if (NavigationManager != null)
+            {
+                NavigationManager.PropertyChanged -= NavigationManager_PropertyChanged;
+                NavigationManager.Dispose();
+                NavigationManager = null;
+            }
 
             // remove desktop icons control
             DesktopWindow?.grid.Children.Clear();

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/Clock.xaml
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/Clock.xaml
@@ -1,7 +1,8 @@
 ﻿<UserControl x:Class="CairoDesktop.MenuBarExtensions.Clock"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:l10n="clr-namespace:CairoDesktop.Common.Localization;assembly=CairoDesktop.Common">
+             xmlns:l10n="clr-namespace:CairoDesktop.Common.Localization;assembly=CairoDesktop.Common"
+             Unloaded="UserControl_Unloaded">
     <Menu Style="{StaticResource CairoMenuBarMainContainerStyle}">
         <MenuItem x:Name="ClockMenuItem"
                   ItemContainerStyle="{StaticResource CairoMenuItemContainerStyle}"

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/Clock.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/Clock.xaml.cs
@@ -15,6 +15,8 @@ namespace CairoDesktop.MenuBarExtensions
         private readonly bool _isPrimaryScreen;
         private static bool isClockHotkeyRegistered;
 
+        private DispatcherTimer _clock;
+
         public Clock(IMenuBar host, ICommandService commandService, Settings settings)
         {
             InitializeComponent();
@@ -32,13 +34,12 @@ namespace CairoDesktop.MenuBarExtensions
             UpdateTextAndToolTip();
 
             // Create our timer for clock
-            DispatcherTimer clock = new DispatcherTimer(new TimeSpan(0, 0, 0, 0, 500), DispatcherPriority.Background, Clock_Tick, Dispatcher);
+            _clock = new DispatcherTimer(new TimeSpan(0, 0, 0, 0, 500), DispatcherPriority.Background, Clock_Tick, Dispatcher);
 
             if (_isPrimaryScreen)
             {
                 // register time changed handler to receive time zone updates for the clock to update correctly
                 Microsoft.Win32.SystemEvents.TimeChanged += new EventHandler(TimeChanged);
-                Dispatcher.ShutdownStarted += Dispatcher_ShutdownStarted;
 
                 try
                 {
@@ -55,11 +56,6 @@ namespace CairoDesktop.MenuBarExtensions
         private void OnShowClock(HotKey hotKey)
         {
             ToggleClockDisplay();
-        }
-
-        private void Dispatcher_ShutdownStarted(object sender, EventArgs e)
-        {
-            Microsoft.Win32.SystemEvents.TimeChanged -= new EventHandler(TimeChanged);
         }
 
         private void Clock_Tick(object sender, EventArgs args)
@@ -101,6 +97,12 @@ namespace CairoDesktop.MenuBarExtensions
         public void ToggleClockDisplay()
         {
             ClockMenuItem.IsSubmenuOpen = !ClockMenuItem.IsSubmenuOpen;
+        }
+
+        private void UserControl_Unloaded(object sender, RoutedEventArgs e)
+        {
+            Microsoft.Win32.SystemEvents.TimeChanged -= new EventHandler(TimeChanged);
+            _clock.Stop();
         }
     }
 }

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/Search.xaml
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/Search.xaml
@@ -2,7 +2,8 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="clr-namespace:CairoDesktop.MenuBarExtensions"
-             xmlns:l10n="clr-namespace:CairoDesktop.Common.Localization;assembly=CairoDesktop.Common">
+             xmlns:l10n="clr-namespace:CairoDesktop.Common.Localization;assembly=CairoDesktop.Common"
+             Unloaded="UserControl_Unloaded">
     <Menu Style="{StaticResource CairoMenuBarMainContainerStyle}">
         <MenuItem x:Name="CairoSearchMenu"
                   Style="{StaticResource CairoMenuItemCairoSearchMenuStyle}"

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/Search.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/Search.xaml.cs
@@ -16,8 +16,10 @@ namespace CairoDesktop.MenuBarExtensions
     public partial class Search : UserControl
     {
         private readonly ICairoApplication _cairoApplication;
-        public bool _isPrimaryScreen;
         private static bool isSearchHotkeyRegistered;
+
+        public bool _isPrimaryScreen;
+        private DispatcherTimer _searchCheck;
 
         public Search(ICairoApplication cairoApplication, IMenuBar host)
         {
@@ -39,12 +41,12 @@ namespace CairoDesktop.MenuBarExtensions
             else
             {
                 CairoSearchMenu.Visibility = Visibility.Collapsed;
-                DispatcherTimer searchcheck = new DispatcherTimer(DispatcherPriority.Background, Dispatcher)
+                _searchCheck = new DispatcherTimer(DispatcherPriority.Background, Dispatcher)
                 {
                     Interval = new TimeSpan(0, 0, 5)
                 };
-                searchcheck.Tick += searchcheck_Tick;
-                searchcheck.Start();
+                _searchCheck.Tick += searchcheck_Tick;
+                _searchCheck.Start();
             }
         }
 
@@ -160,6 +162,11 @@ namespace CairoDesktop.MenuBarExtensions
         internal void ToggleSearch()
         {
             CairoSearchMenu.IsSubmenuOpen = !CairoSearchMenu.IsSubmenuOpen;
+        }
+
+        private void UserControl_Unloaded(object sender, RoutedEventArgs e)
+        {
+            _searchCheck?.Stop();
         }
     }
 }

--- a/Cairo Desktop/CairoDesktop.Taskbar/QuickLaunchButton.xaml
+++ b/Cairo Desktop/CairoDesktop.Taskbar/QuickLaunchButton.xaml
@@ -8,7 +8,8 @@
              x:Class="CairoDesktop.Taskbar.QuickLaunchButton"
              x:Name="UserControl"
              d:DesignWidth="26"
-             d:DesignHeight="29">
+             d:DesignHeight="29"
+             Unloaded="UserControl_Unloaded">
     <Grid x:Name="LayoutRoot">
         <Button x:Name="btn"
                 CommandParameter="{Binding Path=Path}"

--- a/Cairo Desktop/CairoDesktop.Taskbar/QuickLaunchButton.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.Taskbar/QuickLaunchButton.xaml.cs
@@ -212,5 +212,10 @@ namespace CairoDesktop.Taskbar
                 }
             }
         }
+
+        private void UserControl_Unloaded(object sender, RoutedEventArgs e)
+        {
+            Settings.Instance.PropertyChanged -= Instance_PropertyChanged;
+        }
     }
 }

--- a/Cairo Desktop/CairoDesktop.Taskbar/TaskButton.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.Taskbar/TaskButton.xaml.cs
@@ -11,6 +11,7 @@ using ManagedShell.Common.Helpers;
 using ManagedShell.WindowsTasks;
 using System.Collections.ObjectModel;
 using CairoDesktop.Taskbar.SupportingClasses;
+using System.Windows.Media.Animation;
 
 namespace CairoDesktop.Taskbar
 {
@@ -110,6 +111,25 @@ namespace CairoDesktop.Taskbar
             return SystemParameters.MouseHoverTime.Add(TimeSpan.FromMilliseconds(autoHideDelay));
         }
 
+        private void animate()
+        {
+            var ease = new SineEase();
+            ease.EasingMode = EasingMode.EaseInOut;
+
+            DoubleAnimation animation = new DoubleAnimation();
+            animation.From = 0;
+            animation.To = ParentTaskbar?.ButtonWidth ?? ActualWidth;
+            animation.Duration = new Duration(TimeSpan.FromMilliseconds(250));
+            animation.FillBehavior = FillBehavior.Stop;
+            animation.EasingFunction = ease;
+            Storyboard.SetTarget(animation, this);
+            Storyboard.SetTargetProperty(animation, new PropertyPath(WidthProperty));
+
+            Storyboard storyboard = new Storyboard();
+            storyboard.Children.Add(animation);
+            storyboard.Begin();
+        }
+
         #region Events
         private void UserControl_Loaded(object sender, RoutedEventArgs e)
         {
@@ -132,6 +152,7 @@ namespace CairoDesktop.Taskbar
                 setLabelVisibility();
                 setIconSize();
                 setToolTip();
+                animate();
             }
             else
             {

--- a/Cairo Desktop/CairoDesktop.Taskbar/Taskbar.xaml
+++ b/Cairo Desktop/CairoDesktop.Taskbar/Taskbar.xaml
@@ -231,28 +231,11 @@
                                                                 <ControlTemplate TargetType="GroupItem">
                                                                     <ContentControl Style="{StaticResource TaskbarGroup}">
                                                                         <Border BorderThickness="0"
-                                                                                Margin="0,0,-1,0"
-                                                                                Width="{Binding Path=ButtonWidth, ElementName=TaskbarWindow}">
+                                                                                Margin="0,0,-1,0">
                                                                             <self:TaskButton ListMode="False"
                                                                                              ParentTaskbar="{Binding ElementName=TaskbarWindow}"
-                                                                                             DataContext="{Binding Converter={StaticResource groupConverter}}" />
-                                                                            <Border.Triggers>
-                                                                                <EventTrigger RoutedEvent="Loaded">
-                                                                                    <BeginStoryboard>
-                                                                                        <Storyboard>
-                                                                                            <DoubleAnimation Storyboard.TargetProperty="Width"
-                                                                                                             From="0"
-                                                                                                             To="{Binding Path=ButtonWidth, ElementName=TaskbarWindow}"
-                                                                                                             Duration="0:0:0.2"
-                                                                                                             FillBehavior="Stop">
-                                                                                                <DoubleAnimation.EasingFunction>
-                                                                                                    <QuadraticEase EasingMode="EaseInOut" />
-                                                                                                </DoubleAnimation.EasingFunction>
-                                                                                            </DoubleAnimation>
-                                                                                        </Storyboard>
-                                                                                    </BeginStoryboard>
-                                                                                </EventTrigger>
-                                                                            </Border.Triggers>
+                                                                                             DataContext="{Binding Converter={StaticResource groupConverter}}"
+                                                                                             Width="{Binding Path=ButtonWidth, ElementName=TaskbarWindow}" />
                                                                         </Border>
                                                                     </ContentControl>
                                                                 </ControlTemplate>
@@ -271,11 +254,11 @@
                                     <Setter Property="Template">
                                         <Setter.Value>
                                             <ControlTemplate TargetType="{x:Type ListViewItem}">
-                                                <Border BorderThickness="0" Margin="0,0,-1,0" BorderBrush="Transparent"
-                                                        Width="{Binding Path=ButtonWidth, ElementName=TaskbarWindow}">
+                                                <Border BorderThickness="0" Margin="0,0,-1,0" BorderBrush="Transparent">
                                                     <self:TaskButton ListMode="False"
                                                                      MouseRightButtonUp="TaskButton_MouseRightButtonUp"
-                                                                     ParentTaskbar="{Binding ElementName=TaskbarWindow}" />
+                                                                     ParentTaskbar="{Binding ElementName=TaskbarWindow}"
+                                                                     Width="{Binding Path=ButtonWidth, ElementName=TaskbarWindow}" />
                                                     <Border.Style>
                                                         <Style TargetType="{x:Type Border}">
                                                             <Setter Property="Visibility" Value="Collapsed" />
@@ -287,23 +270,6 @@
                                                             </Style.Triggers>
                                                         </Style>
                                                     </Border.Style>
-                                                    <Border.Triggers>
-                                                        <EventTrigger RoutedEvent="Loaded">
-                                                            <BeginStoryboard>
-                                                                <Storyboard>
-                                                                    <DoubleAnimation Storyboard.TargetProperty="Width"
-                                                                                     From="0"
-                                                                                     To="{Binding Path=ButtonWidth, ElementName=TaskbarWindow}"
-                                                                                     Duration="0:0:0.2"
-                                                                                     FillBehavior="Stop">
-                                                                        <DoubleAnimation.EasingFunction>
-                                                                            <QuadraticEase EasingMode="EaseInOut" />
-                                                                        </DoubleAnimation.EasingFunction>
-                                                                    </DoubleAnimation>
-                                                                </Storyboard>
-                                                            </BeginStoryboard>
-                                                        </EventTrigger>
-                                                    </Border.Triggers>
                                                 </Border>
                                             </ControlTemplate>
                                         </Setter.Value>

--- a/Cairo Desktop/CairoDesktop.Taskbar/Taskbar.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.Taskbar/Taskbar.xaml.cs
@@ -112,8 +112,6 @@ namespace CairoDesktop.Taskbar
 
             // setup taskbar item source
 
-            _shellManager.Tasks.Initialize(getTaskCategoryProvider(), true);
-
             _taskbarItems = _shellManager.Tasks.CreateGroupedWindowsCollection();
             _taskbarItems.Filter = Tasks_Filter;
 
@@ -166,18 +164,6 @@ namespace CairoDesktop.Taskbar
             }
 
             return true;
-        }
-
-        private ITaskCategoryProvider getTaskCategoryProvider()
-        {
-            if (_settings.TaskbarGroupingStyle == 0)
-            {
-                return new AppGrabberTaskCategoryProvider(_appGrabber, _shellManager);
-            }
-            else
-            {
-                return new ApplicationTaskCategoryProvider();
-            }
         }
 
         private void setupTaskbarAppearance()
@@ -327,6 +313,7 @@ namespace CairoDesktop.Taskbar
         {
             if (_windowManager?.IsSettingDisplays == true || AllowClose)
             {
+                _taskbarItems.Filter = null;
                 _taskbarItems.CollectionChanged -= GroupedWindows_Changed;
                 _windowManager.ScreensChanged -= WindowManager_ScreensChanged;
                 _settings.PropertyChanged -= Settings_PropertyChanged;
@@ -405,7 +392,6 @@ namespace CairoDesktop.Taskbar
                     setTaskbarBlur();
                     break;
                 case "TaskbarGroupingStyle":
-                    _shellManager.Tasks.SetTaskCategoryProvider(getTaskCategoryProvider());
                     setTaskButtonSize();
                     break;
                 case "EnableTaskbarMultiMon":


### PR DESCRIPTION
Throughout the application lifecycle, we may close or open these windows for various reasons (display changes, preference changes, etc). Unfortunately, previously these windows would always remain in memory after being closed, for multiple reasons. The changes in this PR plug the leaks that were causing this to happen.

## Menu bar
- Fixed event handler and timer leaks in Clock and Search menu bar extras
- Fixed AppBarWindow leak via ManagedShell update

## Desktop
- Fixed NavigationManager never being disposed
- Fixed event handler leak in DesktopIcons and NavigationManager

## Taskbar
- Multiple fixes for AppGrabberTaskCategoryProvider
  - Fixed the taskbar creating multiple instances of the provider, when only one is needed at a time, by moving the logic to TaskbarWindowService
  - Fixed event handler leaks in the class
  - Fixed CategoryChanged event for the "All" category causing unnecessary work
  - Also fixed `TryGetCategoryDisplayNameByProcId` to not return the current window
- Fixed event handler leak in QuickLaunchButton and Taskbar
- Fixed task button animations to no longer keep references to the control
- Fixed AppBarWindow leak via ManagedShell update