### PR TITLE
Add timer to delay TaskThumbWindow closing

### DIFF
--- a/Cairo Desktop/CairoDesktop.Taskbar/TaskButton.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.Taskbar/TaskButton.xaml.cs
@@ -36,6 +36,7 @@ namespace CairoDesktop.Taskbar
 
         private DispatcherTimer dragTimer;
         private DispatcherTimer thumbTimer;
+        private DispatcherTimer closeThumbTimer;
         public TaskThumbWindow ThumbWindow;
         private TaskGroup taskGroup;
 
@@ -172,6 +173,10 @@ namespace CairoDesktop.Taskbar
             // thumbnails - delayed activation using system setting
             thumbTimer = new DispatcherTimer { Interval = interval };
             thumbTimer.Tick += thumbTimer_Tick;
+
+            // thumbnails - delayed closing
+            closeThumbTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(50) };
+            closeThumbTimer.Tick += closeThumbTimer_Tick;
         }
 
         private void TaskButton_OnUnloaded(object sender, RoutedEventArgs e)
@@ -330,7 +335,7 @@ namespace CairoDesktop.Taskbar
             if (!ListMode)
             {
                 thumbTimer.Stop();
-                closeThumb();
+                closeThumbTimer.Start();
             }
         }
         #endregion
@@ -478,6 +483,14 @@ namespace CairoDesktop.Taskbar
         {
             thumbTimer.Stop();
             if (IsMouseOver) openThumb();
+        }
+
+        private void closeThumbTimer_Tick(object sender, EventArgs e)
+        {
+            closeThumbTimer.Stop();
+
+            if (!IsMouseOver)
+                closeThumb();
         }
 
         private void openThumb()


### PR DESCRIPTION
Added another timer to TaskButton.xaml.cs to prevent the TaskThumbWindow from closing prematurely.

I couldn’t find any built-in constant for the “mouse away” delay, so I set it to 50 ms, which felt adequate during testing.

Fixes #914 

Demo:

https://github.com/user-attachments/assets/6ef3d5fd-0a9a-450b-bc8f-486adc8f1ec3

