### PR TITLE
Fix clock no longer updating

### DIFF
--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/Clock.xaml
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/Clock.xaml
@@ -2,6 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:l10n="clr-namespace:CairoDesktop.Common.Localization;assembly=CairoDesktop.Common"
+             Loaded="UserControl_Loaded"
              Unloaded="UserControl_Unloaded">
     <Menu Style="{StaticResource CairoMenuBarMainContainerStyle}">
         <MenuItem x:Name="ClockMenuItem"

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/Clock.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/Clock.xaml.cs
@@ -25,7 +25,10 @@ namespace CairoDesktop.MenuBarExtensions
             _settings = settings;
 
             _isPrimaryScreen = host.GetIsPrimaryDisplay();
+        }
 
+        private void UserControl_Loaded(object sender, RoutedEventArgs e)
+        {
             InitializeClock();
         }
 


### PR DESCRIPTION
When the control is unloaded and then loaded again, nothing was restarting the timer.