### PR TITLE
Fix leaks, related refactors and improvements

### DIFF
--- a/Cairo Desktop/Cairo Desktop/Cairo Desktop.csproj
+++ b/Cairo Desktop/Cairo Desktop/Cairo Desktop.csproj
@@ -65,7 +65,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedShell" Version="0.0.334" />
+    <PackageReference Include="ManagedShell" Version="0.0.337" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/Cairo Desktop/Cairo Desktop/Program.cs
+++ b/Cairo Desktop/Cairo Desktop/Program.cs
@@ -19,6 +19,7 @@ using CairoDesktop.DynamicDesktop.Services;
 using CairoDesktop.MenuBar.Services;
 using CairoDesktop.Taskbar.Services;
 using CairoDesktop.AppGrabber.Commands;
+using CairoDesktop.MenuBar.Commands;
 
 namespace CairoDesktop
 {
@@ -62,6 +63,7 @@ namespace CairoDesktop
 
                     services.AddSingleton<ISettingsUIService, SettingsUIService>();
 
+                    services.AddHostedService<MenuBarHotKeyService>();
                     services.AddHostedService<ShellHotKeyService>();
 
                     services.AddSingleton<IThemeService, CairoApplicationThemeService>();
@@ -119,6 +121,8 @@ namespace CairoDesktop
                     services.AddSingleton<ICairoCommand, TaskViewCommand>();
                     services.AddSingleton<ICairoCommand, AddToProgramsCommand>();
                     services.AddSingleton<ICairoCommand, AddToQuickLaunchCommand>();
+                    services.AddSingleton<ICairoCommand, ToggleCairoMenuCommand>();
+                    services.AddSingleton<ICairoCommand, ToggleProgramsMenuCommand>();
                 })
                 .ConfigureLogging((context, logging) =>
                 {

--- a/Cairo Desktop/Cairo Desktop/SettingsUI.xaml
+++ b/Cairo Desktop/Cairo Desktop/SettingsUI.xaml
@@ -436,34 +436,28 @@
                     <StackPanel Orientation="Horizontal">
                         <StackPanel Orientation="Vertical">
                             <CheckBox IsChecked="{Binding Path=EnablePlacesMenu, UpdateSourceTrigger=PropertyChanged}"
-                                      Click="CheckBox_Click"
                                       Name="chkEnablePlacesMenu">
                                 <Label Content="{Binding Path=(l10n:DisplayString.sPlacesMenu)}" />
                             </CheckBox>
                             <CheckBox IsChecked="{Binding Path=EnableMenuExtraClock, UpdateSourceTrigger=PropertyChanged}"
-                                      Click="CheckBox_Click"
                                       Name="chkEnableMenuExtraClock">
                                 <Label Content="{Binding Path=(l10n:DisplayString.sSettings_MenuBar_EnableMenuExtraClock)}" />
                             </CheckBox>
                             <CheckBox IsChecked="{Binding Path=EnableMenuExtraSearch, UpdateSourceTrigger=PropertyChanged}"
-                                      Click="CheckBox_Click"
                                       Name="chkEnableMenuExtraSearch">
                                 <Label Content="{Binding Path=(l10n:DisplayString.sSettings_MenuBar_EnableMenuExtraSearch)}" />
                             </CheckBox>
                         </StackPanel>
                         <StackPanel Orientation="Vertical" Margin="10,0,0,0">
                             <CheckBox IsChecked="{Binding Path=EnableProgramsMenu, UpdateSourceTrigger=PropertyChanged}"
-                                      Click="CheckBox_Click"
                                       Name="chkEnablePrgoramsMenu">
                                 <Label Content="{Binding Path=(l10n:DisplayString.sProgramsMenu)}" />
                             </CheckBox>
                             <CheckBox IsChecked="{Binding Path=EnableMenuExtraVolume, UpdateSourceTrigger=PropertyChanged}"
-                                      Click="CheckBox_Click"
                                       Name="chkEnableMenuExtraVolume">
                                 <Label Content="{Binding Path=(l10n:DisplayString.sSettings_MenuBar_EnableMenuExtraVolume)}" />
                             </CheckBox>
                             <CheckBox IsChecked="{Binding Path=EnableMenuExtraActionCenter, UpdateSourceTrigger=PropertyChanged}"
-                                      Click="CheckBox_Click"
                                       Name="chkEnableMenuExtraActionCenter">
                                 <Label Content="{Binding Path=(l10n:DisplayString.sSettings_MenuBar_EnableMenuExtraActionCenter)}" />
                             </CheckBox>

--- a/Cairo Desktop/CairoDesktop.AppGrabber/AppGrabberService.cs
+++ b/Cairo Desktop/CairoDesktop.AppGrabber/AppGrabberService.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Windows;
 using System.Windows.Data;
@@ -275,6 +276,7 @@ namespace CairoDesktop.AppGrabber
                         link.GetPath(builder, 260, out ManagedShell.ShellFolders.Structs.WIN32_FIND_DATA pfd, ManagedShell.ShellFolders.Enums.SLGP_FLAGS.SLGP_RAWPATH);
 
                         target = builder.ToString();
+                        Marshal.FinalReleaseComObject(link);
                     }
                     catch (Exception ex)
                     {

--- a/Cairo Desktop/CairoDesktop.Common/CairoDesktop.Common.csproj
+++ b/Cairo Desktop/CairoDesktop.Common/CairoDesktop.Common.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ManagedShell" Version="0.0.334" />
+    <PackageReference Include="ManagedShell" Version="0.0.337" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />

--- a/Cairo Desktop/CairoDesktop.Common/Helpers/CursorHelper.cs
+++ b/Cairo Desktop/CairoDesktop.Common/Helpers/CursorHelper.cs
@@ -1,0 +1,32 @@
+﻿using System.Drawing;
+using ManagedShell.AppBar;
+using System.Windows.Forms;
+
+namespace CairoDesktop.Common.Helpers
+{
+    public static class CursorHelper
+    {
+        public static bool IsCursorOnScreen(Screen screen)
+        {
+            return IsCursorInRectangle(screen.Bounds);
+        }
+
+        public static bool IsCursorOnScreen(AppBarScreen screen)
+        {
+            return IsCursorInRectangle(screen.Bounds);
+        }
+
+        private static bool IsCursorInRectangle(Rectangle bounds)
+        {
+            var cursorPos = Cursor.Position;
+
+            if (cursorPos.X >= bounds.Left && cursorPos.X <= bounds.Right &&
+                cursorPos.Y >= bounds.Top && cursorPos.Y <= bounds.Bottom)
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Cairo Desktop/CairoDesktop.Common/Localization/DisplayString.cs
+++ b/Cairo Desktop/CairoDesktop.Common/Localization/DisplayString.cs
@@ -730,5 +730,9 @@ namespace CairoDesktop.Common.Localization
         public static string sCommand_AddToPrograms => getString();
 
         public static string sCommand_AddToQuickLaunch => getString();
+
+        public static string sCommand_ToggleCairoMenu => getString();
+
+        public static string sCommand_ToggleProgramsMenu => getString();
     }
 }

--- a/Cairo Desktop/CairoDesktop.Common/Localization/Language.cs
+++ b/Cairo Desktop/CairoDesktop.Common/Localization/Language.cs
@@ -308,6 +308,8 @@ namespace CairoDesktop.Common.Localization
             { "sCommand_CloseDesktopOverlay", "Close Desktop Overlay" },
             { "sCommand_AddToPrograms", "Add to programs menu" },
             { "sCommand_AddToQuickLaunch", "Add to quick launch" },
+            { "sCommand_ToggleCairoMenu", "Toggle Cairo Menu" },
+            { "sCommand_ToggleProgramsMenu", "Toggle Programs Menu" },
         };
 
         public static Dictionary<string, string> pt_BR = new Dictionary<string, string>

--- a/Cairo Desktop/CairoDesktop.Infrastructure/ObjectModel/UserControlMenuBarExtension.cs
+++ b/Cairo Desktop/CairoDesktop.Infrastructure/ObjectModel/UserControlMenuBarExtension.cs
@@ -8,6 +8,6 @@ namespace CairoDesktop.Infrastructure.ObjectModel
         public abstract UserControl StartControl(IMenuBar host);
 
         // Optional as some controls may not need to do anything to stop
-        public virtual void StopControl(IMenuBar host) { }
+        public virtual void StopControl(IMenuBar host, UserControl control) { }
     }
 }

--- a/Cairo Desktop/CairoDesktop.Infrastructure/ObjectModel/UserControlMenuBarExtension.cs
+++ b/Cairo Desktop/CairoDesktop.Infrastructure/ObjectModel/UserControlMenuBarExtension.cs
@@ -6,5 +6,8 @@ namespace CairoDesktop.Infrastructure.ObjectModel
     public abstract class UserControlMenuBarExtension : IMenuBarExtension<UserControl>
     {
         public abstract UserControl StartControl(IMenuBar host);
+
+        // Optional as some controls may not need to do anything to stop
+        public virtual void StopControl(IMenuBar host) { }
     }
 }

--- a/Cairo Desktop/CairoDesktop.MenuBar/Commands/ToggleCairoMenuCommand.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBar/Commands/ToggleCairoMenuCommand.cs
@@ -5,7 +5,7 @@ using CairoDesktop.Common.Localization;
 using CairoDesktop.Infrastructure.ObjectModel;
 using CairoDesktop.MenuBar.Services;
 using System.Collections.Generic;
-using System.Windows.Forms;
+using CairoDesktop.Common.Helpers;
 
 namespace CairoDesktop.MenuBar.Commands
 {
@@ -37,14 +37,9 @@ namespace CairoDesktop.MenuBar.Commands
                 return false;
             }
 
-            int x = Cursor.Position.X;
-            int y = Cursor.Position.Y;
-
             foreach (MenuBar menuBar in _windowService.Windows)
             {
-                if (!_settings.EnableMenuBarMultiMon || 
-                    (x >= menuBar.Screen.Bounds.Left && x <= menuBar.Screen.Bounds.Right &&
-                    y >= menuBar.Screen.Bounds.Top && y <= menuBar.Screen.Bounds.Bottom))
+                if (!_settings.EnableMenuBarMultiMon || CursorHelper.IsCursorOnScreen(menuBar.Screen))
                 {
                     menuBar.ToggleCairoMenu();
                     return true;

--- a/Cairo Desktop/CairoDesktop.MenuBar/Commands/ToggleCairoMenuCommand.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBar/Commands/ToggleCairoMenuCommand.cs
@@ -1,0 +1,70 @@
+﻿using CairoDesktop.Application.Interfaces;
+using CairoDesktop.Application.Structs;
+using CairoDesktop.Common;
+using CairoDesktop.Common.Localization;
+using CairoDesktop.Infrastructure.ObjectModel;
+using CairoDesktop.MenuBar.Services;
+using System.Collections.Generic;
+using System.Windows.Forms;
+
+namespace CairoDesktop.MenuBar.Commands
+{
+    public class ToggleCairoMenuCommand : ICairoCommand
+    {
+        public ICairoCommandInfo Info => _info;
+
+        private readonly Settings _settings;
+        private readonly MenuBarWindowService _windowService;
+        private readonly ToggleCairoMenuCommandInfo _info = new ToggleCairoMenuCommandInfo();
+
+        public ToggleCairoMenuCommand(IEnumerable<IWindowService> windowServices, Settings settings)
+        {
+            foreach (var windowService in windowServices)
+            {
+                if (windowService is MenuBarWindowService menuBarWindowService)
+                {
+                    _windowService = menuBarWindowService;
+                }
+            }
+
+            _settings = settings;
+        }
+
+        public bool Execute(params (string name, object value)[] parameters)
+        {
+            if (_windowService == null)
+            {
+                return false;
+            }
+
+            int x = Cursor.Position.X;
+            int y = Cursor.Position.Y;
+
+            foreach (MenuBar menuBar in _windowService.Windows)
+            {
+                if (!_settings.EnableMenuBarMultiMon || 
+                    (x >= menuBar.Screen.Bounds.Left && x <= menuBar.Screen.Bounds.Right &&
+                    y >= menuBar.Screen.Bounds.Top && y <= menuBar.Screen.Bounds.Bottom))
+                {
+                    menuBar.ToggleCairoMenu();
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
+    public class ToggleCairoMenuCommandInfo : ICairoCommandInfo
+    {
+        public string Identifier => "ToggleCairoMenu";
+
+        public string Description => "Toggles the Cairo menu.";
+
+        public string Label => DisplayString.sCommand_ToggleCairoMenu;
+
+        public bool IsAvailable => true;
+
+        public IReadOnlyCollection<CairoCommandParameter> Parameters => null;
+    }
+}

--- a/Cairo Desktop/CairoDesktop.MenuBar/Commands/ToggleProgramsMenuCommand.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBar/Commands/ToggleProgramsMenuCommand.cs
@@ -6,7 +6,7 @@ using CairoDesktop.Infrastructure.ObjectModel;
 using CairoDesktop.MenuBar.Services;
 using System;
 using System.Collections.Generic;
-using System.Windows.Forms;
+using CairoDesktop.Common.Helpers;
 
 namespace CairoDesktop.MenuBar.Commands
 {
@@ -53,14 +53,9 @@ namespace CairoDesktop.MenuBar.Commands
                 return false;
             }
 
-            int x = Cursor.Position.X;
-            int y = Cursor.Position.Y;
-
             foreach (MenuBar menuBar in _windowService.Windows)
             {
-                if (!_settings.EnableMenuBarMultiMon ||
-                    (x >= menuBar.Screen.Bounds.Left && x <= menuBar.Screen.Bounds.Right &&
-                    y >= menuBar.Screen.Bounds.Top && y <= menuBar.Screen.Bounds.Bottom))
+                if (!_settings.EnableMenuBarMultiMon || CursorHelper.IsCursorOnScreen(menuBar.Screen))
                 {
                     menuBar.ToggleProgramsMenu();
                     return true;

--- a/Cairo Desktop/CairoDesktop.MenuBar/Commands/ToggleProgramsMenuCommand.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBar/Commands/ToggleProgramsMenuCommand.cs
@@ -1,0 +1,99 @@
+﻿using CairoDesktop.Application.Interfaces;
+using CairoDesktop.Application.Structs;
+using CairoDesktop.Common;
+using CairoDesktop.Common.Localization;
+using CairoDesktop.Infrastructure.ObjectModel;
+using CairoDesktop.MenuBar.Services;
+using System;
+using System.Collections.Generic;
+using System.Windows.Forms;
+
+namespace CairoDesktop.MenuBar.Commands
+{
+    public class ToggleProgramsMenuCommand : ICairoCommand, IDisposable
+    {
+        public ICairoCommandInfo Info => _info;
+
+        private readonly Settings _settings;
+        private readonly MenuBarWindowService _windowService;
+        private readonly ToggleProgramsMenuCommandInfo _info = new ToggleProgramsMenuCommandInfo();
+
+        public ToggleProgramsMenuCommand(IEnumerable<IWindowService> windowServices, Settings settings)
+        {
+            foreach (var windowService in windowServices)
+            {
+                if (windowService is MenuBarWindowService menuBarWindowService)
+                {
+                    _windowService = menuBarWindowService;
+                }
+            }
+
+            _settings = settings;
+            _settings.PropertyChanged += Settings_PropertyChanged;
+            SetAvailable();
+        }
+
+        private void SetAvailable()
+        {
+            _info.IsAvailable = _settings.EnableProgramsMenu;
+        }
+
+        private void Settings_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (e?.PropertyName == nameof(_settings.EnableProgramsMenu))
+            {
+                SetAvailable();
+            }
+        }
+
+        public bool Execute(params (string name, object value)[] parameters)
+        {
+            if (_windowService == null || !_settings.EnableProgramsMenu)
+            {
+                return false;
+            }
+
+            int x = Cursor.Position.X;
+            int y = Cursor.Position.Y;
+
+            foreach (MenuBar menuBar in _windowService.Windows)
+            {
+                if (!_settings.EnableMenuBarMultiMon ||
+                    (x >= menuBar.Screen.Bounds.Left && x <= menuBar.Screen.Bounds.Right &&
+                    y >= menuBar.Screen.Bounds.Top && y <= menuBar.Screen.Bounds.Bottom))
+                {
+                    menuBar.ToggleProgramsMenu();
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public void Dispose()
+        {
+            _settings.PropertyChanged -= Settings_PropertyChanged;
+        }
+    }
+
+    public class ToggleProgramsMenuCommandInfo : ICairoCommandInfo
+    {
+        public string Identifier => "ToggleProgramsMenu";
+
+        public string Description => "Toggles the programs menu.";
+
+        public string Label => DisplayString.sCommand_ToggleProgramsMenu;
+
+        private bool _isAvailable;
+        public bool IsAvailable
+        {
+            get => _isAvailable;
+            internal set
+            {
+                _isAvailable = value;
+            }
+        }
+
+        public IReadOnlyCollection<CairoCommandParameter> Parameters => null;
+    }
+}

--- a/Cairo Desktop/CairoDesktop.MenuBar/Services/MenuBarHotKeyService.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBar/Services/MenuBarHotKeyService.cs
@@ -1,0 +1,137 @@
+﻿using CairoDesktop.Application.Interfaces;
+using CairoDesktop.Common;
+using CairoDesktop.Infrastructure.DependencyInjection;
+using ManagedShell.Common.Helpers;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Windows.Input;
+
+namespace CairoDesktop.MenuBar.Services
+{
+    public sealed class MenuBarHotKeyService : CairoBackgroundService
+    {
+        private HotKey cairoMenuHotKey;
+        private List<HotKey> programsMenuHotKeys = new List<HotKey>();
+
+        // private LowLevelKeyboardListener keyboardListener; // temporarily removed due to stuck key issue, commented out to prevent warnings
+
+        private readonly ICairoApplication _cairoApplication;
+        private readonly ICommandService _commandService;
+        private readonly Settings _settings;
+
+        public MenuBarHotKeyService(ICairoApplication cairoApplication, ICommandService commandService, Settings settings)
+        {
+            _cairoApplication = cairoApplication;
+            _settings = settings;
+            _settings.PropertyChanged += Settings_PropertyChanged;
+
+            ServiceStartTask = new Task(RegisterHotkeys);
+            _commandService = commandService;
+        }
+
+        private void Settings_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (e == null || string.IsNullOrWhiteSpace(e.PropertyName)) return;
+
+            switch (e.PropertyName)
+            {
+                case nameof(_settings.CairoMenuHotKey):
+                    if (_settings.EnableCairoMenuHotKey)
+                    {
+                        unregisterCairoMenuHotKey();
+                        registerCairoMenuHotKey();
+                    }
+
+                    break;
+                case nameof(_settings.EnableCairoMenuHotKey):
+                    if (_settings.EnableCairoMenuHotKey)
+                    {
+                        registerCairoMenuHotKey();
+                    }
+                    else
+                    {
+                        unregisterCairoMenuHotKey();
+                    }
+
+                    break;
+                case nameof(_settings.EnableProgramsMenu):
+                case nameof(_settings.EnableWinKey):
+                    if (_settings.EnableWinKey && _settings.EnableProgramsMenu)
+                    {
+                        registerWinKey();
+                    }
+                    else
+                    {
+                        unregisterWinKey();
+                    }
+                    break;
+            }
+        }
+
+        private void RegisterHotkeys()
+        {
+            registerCairoMenuHotKey();
+            registerWinKey();
+        }
+
+        private void registerCairoMenuHotKey()
+        {
+            if (!_settings.EnableCairoMenuHotKey)
+            {
+                return;
+            }
+
+            _cairoApplication.Dispatch(() =>
+            {
+                cairoMenuHotKey = HotKeyManager.RegisterHotKey(_settings.CairoMenuHotKey, OnToggleCairoMenu);
+            });
+        }
+
+        private void registerWinKey()
+        {
+            if (!EnvironmentHelper.IsAppRunningAsShell || !_settings.EnableWinKey || !_settings.EnableProgramsMenu)
+            {
+                return;
+            }
+
+            _cairoApplication.Dispatch(() =>
+            {
+                /*if (keyboardListener == null)
+                    keyboardListener = new LowLevelKeyboardListener();
+
+                keyboardListener.OnKeyPressed += keyboardListener_OnKeyPressed;
+                keyboardListener.HookKeyboard();*/
+
+                programsMenuHotKeys.Add(new HotKey(Key.LWin, HotKeyModifier.Win | HotKeyModifier.NoRepeat, OnToggleProgramsMenu));
+                programsMenuHotKeys.Add(new HotKey(Key.RWin, HotKeyModifier.Win | HotKeyModifier.NoRepeat, OnToggleProgramsMenu));
+                programsMenuHotKeys.Add(new HotKey(Key.Escape, HotKeyModifier.Ctrl | HotKeyModifier.NoRepeat, OnToggleProgramsMenu));
+            });
+        }
+
+        private void unregisterCairoMenuHotKey()
+        {
+            cairoMenuHotKey?.Dispose();
+            cairoMenuHotKey = null;
+        }
+
+        private void unregisterWinKey()
+        {
+            foreach (var hotkey in programsMenuHotKeys)
+            {
+                hotkey.Unregister();
+            }
+
+            programsMenuHotKeys.Clear();
+        }
+
+        private void OnToggleCairoMenu(HotKey obj)
+        {
+            _commandService.InvokeCommand("ToggleCairoMenu");
+        }
+
+        private void OnToggleProgramsMenu(HotKey obj)
+        {
+            _commandService.InvokeCommand("ToggleProgramsMenu");
+        }
+    }
+}

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/Clock.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/Clock.xaml.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Input;
 using System.Windows.Threading;
 using CairoDesktop.Application.Interfaces;
 
@@ -10,10 +9,10 @@ namespace CairoDesktop.MenuBarExtensions
 {
     public partial class Clock : UserControl
     {
+        internal IMenuBar Host;
+
         private readonly ICommandService _commandService;
         private readonly Settings _settings;
-        private readonly bool _isPrimaryScreen;
-        private static bool isClockHotkeyRegistered;
 
         private DispatcherTimer _clock;
 
@@ -21,10 +20,10 @@ namespace CairoDesktop.MenuBarExtensions
         {
             InitializeComponent();
 
+            Host = host;
+
             _commandService = commandService;
             _settings = settings;
-
-            _isPrimaryScreen = host.GetIsPrimaryDisplay();
         }
 
         private void UserControl_Loaded(object sender, RoutedEventArgs e)
@@ -38,27 +37,6 @@ namespace CairoDesktop.MenuBarExtensions
 
             // Create our timer for clock
             _clock = new DispatcherTimer(new TimeSpan(0, 0, 0, 0, 500), DispatcherPriority.Background, Clock_Tick, Dispatcher);
-
-            if (_isPrimaryScreen)
-            {
-                // register time changed handler to receive time zone updates for the clock to update correctly
-                Microsoft.Win32.SystemEvents.TimeChanged += new EventHandler(TimeChanged);
-
-                try
-                {
-                    if (!isClockHotkeyRegistered)
-                    {
-                        new HotKey(Key.D, HotKeyModifier.Win | HotKeyModifier.Alt | HotKeyModifier.NoRepeat, OnShowClock);
-                        isClockHotkeyRegistered = true;
-                    }
-                }
-                catch { }
-            }
-        }
-
-        private void OnShowClock(HotKey hotKey)
-        {
-            ToggleClockDisplay();
         }
 
         private void Clock_Tick(object sender, EventArgs args)
@@ -92,11 +70,6 @@ namespace CairoDesktop.MenuBarExtensions
             monthCalendar.DisplayDate = DateTime.Now;
         }
 
-        private void TimeChanged(object sender, EventArgs e)
-        {
-            TimeZoneInfo.ClearCachedData();
-        }
-
         public void ToggleClockDisplay()
         {
             ClockMenuItem.IsSubmenuOpen = !ClockMenuItem.IsSubmenuOpen;
@@ -104,7 +77,6 @@ namespace CairoDesktop.MenuBarExtensions
 
         private void UserControl_Unloaded(object sender, RoutedEventArgs e)
         {
-            Microsoft.Win32.SystemEvents.TimeChanged -= new EventHandler(TimeChanged);
             _clock.Stop();
         }
     }

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/ClockMenuBarExtension.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/ClockMenuBarExtension.cs
@@ -1,7 +1,10 @@
 ﻿using CairoDesktop.Application.Interfaces;
 using CairoDesktop.Common;
 using CairoDesktop.Infrastructure.ObjectModel;
+using System;
+using System.Collections.Generic;
 using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace CairoDesktop.MenuBarExtensions
 {
@@ -9,12 +12,21 @@ namespace CairoDesktop.MenuBarExtensions
     {
         private readonly ICommandService _commandService;
         private readonly Settings _settings;
-        private Clock _clock;
+        private List<Clock> _clocks = new List<Clock>();
 
         internal ClockMenuBarExtension(ICommandService commandService, Settings settings)
         {
             _commandService = commandService;
             _settings = settings;
+
+            try
+            {
+                new HotKey(Key.D, HotKeyModifier.Win | HotKeyModifier.Alt | HotKeyModifier.NoRepeat, OnShowClock);
+            }
+            catch { }
+
+            // register time changed handler to receive time zone updates for the clock to update correctly
+            Microsoft.Win32.SystemEvents.TimeChanged += new EventHandler(TimeChanged);
         }
 
         public override UserControl StartControl(IMenuBar host)
@@ -23,9 +35,63 @@ namespace CairoDesktop.MenuBarExtensions
             {
                 return null;
             }
+            
+            Clock clock = new Clock(host, _commandService, _settings);
+            _clocks.Add(clock);
+            return clock;
+        }
 
-            _clock = new Clock(host, _commandService, _settings);
-            return _clock;
+        public override void StopControl(IMenuBar host)
+        {
+            List<Clock> toRemove = new List<Clock>();
+
+            foreach (Clock clock in _clocks)
+            {
+                if (clock.Host != host)
+                {
+                    continue;
+                }
+
+                clock.Host = null;
+                toRemove.Add(clock);
+            }
+
+            foreach (Clock clock in toRemove)
+            {
+                _clocks.Remove(clock);
+            }
+
+            toRemove.Clear();
+        }
+
+        private void OnShowClock(HotKey hotKey)
+        {
+            int x = System.Windows.Forms.Cursor.Position.X;
+            int y = System.Windows.Forms.Cursor.Position.Y;
+
+            foreach (Clock clock in _clocks)
+            {
+                if (_settings.EnableMenuBarMultiMon)
+                {
+                    System.Windows.Forms.Screen clockScreen = System.Windows.Forms.Screen.FromHandle(clock.Host.GetHandle());
+
+                    if (x >= clockScreen.Bounds.Left && x <= clockScreen.Bounds.Right &&
+                        y >= clockScreen.Bounds.Top && y <= clockScreen.Bounds.Bottom)
+                    {
+                        clock.ToggleClockDisplay();
+                        return;
+                    }
+
+                    continue;
+                }
+
+                clock.ToggleClockDisplay();
+            }
+        }
+
+        private void TimeChanged(object sender, EventArgs e)
+        {
+            TimeZoneInfo.ClearCachedData();
         }
     }
 }

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/ClockMenuBarExtension.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/ClockMenuBarExtension.cs
@@ -12,7 +12,7 @@ namespace CairoDesktop.MenuBarExtensions
     {
         private readonly ICommandService _commandService;
         private readonly Settings _settings;
-        private List<Clock> _clocks = new List<Clock>();
+        private readonly List<Clock> _clocks = new List<Clock>();
 
         internal ClockMenuBarExtension(ICommandService commandService, Settings settings)
         {
@@ -41,27 +41,13 @@ namespace CairoDesktop.MenuBarExtensions
             return clock;
         }
 
-        public override void StopControl(IMenuBar host)
+        public override void StopControl(IMenuBar host, UserControl control)
         {
-            List<Clock> toRemove = new List<Clock>();
-
-            foreach (Clock clock in _clocks)
+            if (control is Clock clock && _clocks.Contains(clock))
             {
-                if (clock.Host != host)
-                {
-                    continue;
-                }
-
                 clock.Host = null;
-                toRemove.Add(clock);
-            }
-
-            foreach (Clock clock in toRemove)
-            {
                 _clocks.Remove(clock);
             }
-
-            toRemove.Clear();
         }
 
         private void OnShowClock(HotKey hotKey)

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/ClockMenuBarExtension.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/ClockMenuBarExtension.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Windows.Controls;
 using System.Windows.Input;
+using CairoDesktop.Common.Helpers;
 
 namespace CairoDesktop.MenuBarExtensions
 {
@@ -52,17 +53,11 @@ namespace CairoDesktop.MenuBarExtensions
 
         private void OnShowClock(HotKey hotKey)
         {
-            int x = System.Windows.Forms.Cursor.Position.X;
-            int y = System.Windows.Forms.Cursor.Position.Y;
-
             foreach (Clock clock in _clocks)
             {
                 if (_settings.EnableMenuBarMultiMon)
                 {
-                    System.Windows.Forms.Screen clockScreen = System.Windows.Forms.Screen.FromHandle(clock.Host.GetHandle());
-
-                    if (x >= clockScreen.Bounds.Left && x <= clockScreen.Bounds.Right &&
-                        y >= clockScreen.Bounds.Top && y <= clockScreen.Bounds.Bottom)
+                    if (CursorHelper.IsCursorOnScreen(System.Windows.Forms.Screen.FromHandle(clock.Host.GetHandle())))
                     {
                         clock.ToggleClockDisplay();
                         return;

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/Search.xaml
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/Search.xaml
@@ -2,10 +2,10 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="clr-namespace:CairoDesktop.MenuBarExtensions"
-             xmlns:l10n="clr-namespace:CairoDesktop.Common.Localization;assembly=CairoDesktop.Common"
-             Unloaded="UserControl_Unloaded">
+             xmlns:l10n="clr-namespace:CairoDesktop.Common.Localization;assembly=CairoDesktop.Common">
     <Menu Style="{StaticResource CairoMenuBarMainContainerStyle}">
         <MenuItem x:Name="CairoSearchMenu"
+                  Visibility="Collapsed"
                   Style="{StaticResource CairoMenuItemCairoSearchMenuStyle}"
                   ItemContainerStyle="{StaticResource CairoMenuItemContainerStyle}"
                   SubmenuOpened="FocusSearchBox">

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/Search.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/Search.xaml.cs
@@ -1,4 +1,6 @@
-﻿using CairoDesktop.Common;
+﻿using CairoDesktop.Application.Interfaces;
+using ManagedShell.Common.Helpers;
+using ManagedShell.Interop;
 using System;
 using System.Threading;
 using System.Windows;
@@ -6,27 +8,23 @@ using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Threading;
-using CairoDesktop.Application.Interfaces;
-using ManagedShell.Common.Helpers;
-using ManagedShell.Common.Logging;
-using ManagedShell.Interop;
 
 namespace CairoDesktop.MenuBarExtensions
 {
     public partial class Search : UserControl
     {
         private readonly ICairoApplication _cairoApplication;
-        private static bool isSearchHotkeyRegistered;
 
-        public bool _isPrimaryScreen;
         private DispatcherTimer _searchCheck;
+        internal IMenuBar Host;
 
         public Search(ICairoApplication cairoApplication, IMenuBar host)
         {
             InitializeComponent();
 
+            Host = host;
+
             _cairoApplication = cairoApplication;
-            _isPrimaryScreen = host.GetIsPrimaryDisplay();
 
             SetupSearch();
         }
@@ -48,11 +46,6 @@ namespace CairoDesktop.MenuBarExtensions
                 _searchCheck.Tick += searchcheck_Tick;
                 _searchCheck.Start();
             }
-        }
-
-        private void OnShowSearchHotkey(HotKey hotKey)
-        {
-            ToggleSearch();
         }
 
         private void searchcheck_Tick(object sender, EventArgs e)
@@ -105,19 +98,6 @@ namespace CairoDesktop.MenuBarExtensions
 
             thread.SetApartmentState(ApartmentState.STA);
             thread.Start();
-
-            try
-            {
-                if (_isPrimaryScreen && !isSearchHotkeyRegistered)
-                {
-                    new HotKey(Key.S, HotKeyModifier.Win | HotKeyModifier.NoRepeat, OnShowSearchHotkey);
-                    isSearchHotkeyRegistered = true;
-                }
-            }
-            catch (Exception ex)
-            {
-                ShellLogger.Warning($"Search: Unable to bind hotkey: {ex.Message}");
-            }
         }
 
         private void btnViewResults_Click(object sender, RoutedEventArgs e)
@@ -161,6 +141,11 @@ namespace CairoDesktop.MenuBarExtensions
 
         internal void ToggleSearch()
         {
+            if (CairoSearchMenu.Visibility != Visibility.Visible)
+            {
+                return;
+            }
+
             CairoSearchMenu.IsSubmenuOpen = !CairoSearchMenu.IsSubmenuOpen;
         }
 

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/SearchMenuBarExtension.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/SearchMenuBarExtension.cs
@@ -11,6 +11,7 @@ using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Threading;
+using CairoDesktop.Common.Helpers;
 
 namespace CairoDesktop.MenuBarExtensions
 {
@@ -135,17 +136,11 @@ namespace CairoDesktop.MenuBarExtensions
 
         private void OnShowSearchHotkey(HotKey hotKey)
         {
-            int x = System.Windows.Forms.Cursor.Position.X;
-            int y = System.Windows.Forms.Cursor.Position.Y;
-
             foreach (Search search in _searchList)
             {
                 if (_settings.EnableMenuBarMultiMon)
                 {
-                    var clockScreen = System.Windows.Forms.Screen.FromHandle(search.Host.GetHandle());
-
-                    if (x >= clockScreen.Bounds.Left && x <= clockScreen.Bounds.Right &&
-                        y >= clockScreen.Bounds.Top && y <= clockScreen.Bounds.Bottom)
+                    if (CursorHelper.IsCursorOnScreen(System.Windows.Forms.Screen.FromHandle(search.Host.GetHandle())))
                     {
                         search.ToggleSearch();
                         return;

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/SearchMenuBarExtension.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/SearchMenuBarExtension.cs
@@ -64,27 +64,13 @@ namespace CairoDesktop.MenuBarExtensions
             return search;
         }
 
-        public override void StopControl(IMenuBar host)
+        public override void StopControl(IMenuBar host, UserControl control)
         {
-            List<Search> toRemove = new List<Search>();
-
-            foreach (Search search in _searchList)
+            if (control is Search search && _searchList.Contains(search))
             {
-                if (search.Host != host)
-                {
-                    continue;
-                }
-
                 search.Host = null;
-                toRemove.Add(search);
-            }
-
-            foreach (Search search in toRemove)
-            {
                 _searchList.Remove(search);
             }
-
-            toRemove.Clear();
         }
 
         private void SetupSearch()

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/SearchMenuBarExtension.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/SearchMenuBarExtension.cs
@@ -1,7 +1,11 @@
-﻿using System.Windows.Controls;
-using CairoDesktop.Application.Interfaces;
+﻿using CairoDesktop.Application.Interfaces;
 using CairoDesktop.Common;
 using CairoDesktop.Infrastructure.ObjectModel;
+using ManagedShell.Common.Logging;
+using System;
+using System.Collections.Generic;
+using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace CairoDesktop.MenuBarExtensions
 {
@@ -9,12 +13,21 @@ namespace CairoDesktop.MenuBarExtensions
     {
         private readonly ICairoApplication _cairoApplication;
         private readonly Settings _settings;
-        private Search _search;
+        private List<Search> _searchList = new List<Search>();
 
         internal SearchMenuBarExtension(ICairoApplication cairoApplication, Settings settings)
         {
             _cairoApplication = cairoApplication;
             _settings = settings;
+
+            try
+            {
+                new HotKey(Key.S, HotKeyModifier.Win | HotKeyModifier.NoRepeat, OnShowSearchHotkey);
+            }
+            catch (Exception ex)
+            {
+                ShellLogger.Warning($"Search: Unable to bind hotkey: {ex.Message}");
+            }
         }
 
         public override UserControl StartControl(IMenuBar host)
@@ -22,8 +35,57 @@ namespace CairoDesktop.MenuBarExtensions
             if (!_settings.EnableMenuExtraSearch) 
                 return null;
 
-            _search = new Search(_cairoApplication, host);
-            return _search;
+            Search search = new Search(_cairoApplication, host);
+            _searchList.Add(search);
+            return search;
+        }
+
+        public override void StopControl(IMenuBar host)
+        {
+            List<Search> toRemove = new List<Search>();
+
+            foreach (Search search in _searchList)
+            {
+                if (search.Host != host)
+                {
+                    continue;
+                }
+
+                search.Host = null;
+                toRemove.Add(search);
+            }
+
+            foreach (Search search in toRemove)
+            {
+                _searchList.Remove(search);
+            }
+
+            toRemove.Clear();
+        }
+
+        private void OnShowSearchHotkey(HotKey hotKey)
+        {
+            int x = System.Windows.Forms.Cursor.Position.X;
+            int y = System.Windows.Forms.Cursor.Position.Y;
+
+            foreach (Search search in _searchList)
+            {
+                if (_settings.EnableMenuBarMultiMon)
+                {
+                    System.Windows.Forms.Screen clockScreen = System.Windows.Forms.Screen.FromHandle(search.Host.GetHandle());
+
+                    if (x >= clockScreen.Bounds.Left && x <= clockScreen.Bounds.Right &&
+                        y >= clockScreen.Bounds.Top && y <= clockScreen.Bounds.Bottom)
+                    {
+                        search.ToggleSearch();
+                        return;
+                    }
+
+                    continue;
+                }
+
+                search.ToggleSearch();
+            }
         }
     }
 }

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/SearchMenuBarExtension.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/SearchMenuBarExtension.cs
@@ -1,11 +1,16 @@
 ﻿using CairoDesktop.Application.Interfaces;
 using CairoDesktop.Common;
 using CairoDesktop.Infrastructure.ObjectModel;
+using ManagedShell.Common.Helpers;
 using ManagedShell.Common.Logging;
+using ManagedShell.Interop;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Windows.Controls;
+using System.Windows.Data;
 using System.Windows.Input;
+using System.Windows.Threading;
 
 namespace CairoDesktop.MenuBarExtensions
 {
@@ -13,7 +18,9 @@ namespace CairoDesktop.MenuBarExtensions
     {
         private readonly ICairoApplication _cairoApplication;
         private readonly Settings _settings;
-        private List<Search> _searchList = new List<Search>();
+        private readonly List<Search> _searchList = new List<Search>();
+        private ObjectDataProvider _odp;
+        private DispatcherTimer _searchCheck;
 
         internal SearchMenuBarExtension(ICairoApplication cairoApplication, Settings settings)
         {
@@ -28,6 +35,23 @@ namespace CairoDesktop.MenuBarExtensions
             {
                 ShellLogger.Warning($"Search: Unable to bind hotkey: {ex.Message}");
             }
+
+            if (_settings.EnableMenuExtraSearch)
+            {
+                SetupSearch();
+            }
+            _settings.PropertyChanged += Settings_PropertyChanged;
+        }
+
+        private void Settings_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (e?.PropertyName == nameof(_settings.EnableMenuExtraSearch))
+            {
+                if (_odp == null && _settings.EnableMenuExtraSearch)
+                {
+                    SetupSearch();
+                }
+            }
         }
 
         public override UserControl StartControl(IMenuBar host)
@@ -35,7 +59,7 @@ namespace CairoDesktop.MenuBarExtensions
             if (!_settings.EnableMenuExtraSearch) 
                 return null;
 
-            Search search = new Search(_cairoApplication, host);
+            Search search = new Search(host, _odp);
             _searchList.Add(search);
             return search;
         }
@@ -63,6 +87,66 @@ namespace CairoDesktop.MenuBarExtensions
             toRemove.Clear();
         }
 
+        private void SetupSearch()
+        {
+            // Show the search button only if the service is running
+            if (WindowsServices.QueryStatus("WSearch") == ServiceStatus.Running)
+            {
+                SetSearchProvider();
+            }
+            else
+            {
+                _searchCheck = new DispatcherTimer(DispatcherPriority.Background, Dispatcher.CurrentDispatcher)
+                {
+                    Interval = new TimeSpan(0, 0, 5)
+                };
+                _searchCheck.Tick += searchCheck_Tick;
+                _searchCheck.Start();
+            }
+        }
+
+        private void searchCheck_Tick(object sender, EventArgs e)
+        {
+            if (WindowsServices.QueryStatus("WSearch") == ServiceStatus.Running)
+            {
+                SetSearchProvider();
+                (sender as DispatcherTimer)?.Stop();
+            }
+        }
+
+        private void SetSearchProvider()
+        {
+            if (_odp != null)
+            {
+                return;
+            }
+
+            var thread = new Thread(() =>
+            {
+                // this sometimes takes a while
+                Type provider = typeof(SearchHelper);
+
+                _cairoApplication.Dispatch(() =>
+                {
+                    _odp = new ObjectDataProvider
+                    {
+                        ObjectType = provider
+                    };
+
+                    foreach (var search in _searchList)
+                    {
+                        search.SetSearchProvider(_odp);
+                    }
+                });
+            })
+            {
+                IsBackground = true
+            };
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+        }
+
         private void OnShowSearchHotkey(HotKey hotKey)
         {
             int x = System.Windows.Forms.Cursor.Position.X;
@@ -72,7 +156,7 @@ namespace CairoDesktop.MenuBarExtensions
             {
                 if (_settings.EnableMenuBarMultiMon)
                 {
-                    System.Windows.Forms.Screen clockScreen = System.Windows.Forms.Screen.FromHandle(search.Host.GetHandle());
+                    var clockScreen = System.Windows.Forms.Screen.FromHandle(search.Host.GetHandle());
 
                     if (x >= clockScreen.Bounds.Left && x <= clockScreen.Bounds.Right &&
                         y >= clockScreen.Bounds.Top && y <= clockScreen.Bounds.Bottom)

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTray.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTray.xaml.cs
@@ -5,7 +5,6 @@ using System.ComponentModel;
 using CairoDesktop.Application.Interfaces;
 using CairoDesktop.Application.Structs;
 using CairoDesktop.Common;
-using ManagedShell.Common.Helpers;
 using ManagedShell.Interop;
 using ManagedShell.WindowsTray;
 using System.Collections.ObjectModel;
@@ -19,7 +18,7 @@ namespace CairoDesktop.MenuBarExtensions
         private readonly NotificationArea _notificationArea;
         private readonly Settings _settings;
 
-        internal readonly IMenuBar Host;
+        internal IMenuBar Host;
 
         public ObservableCollection<NotifyIcon> PromotedIcons { get; private set; }
 

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTrayMenuBarExtension.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTrayMenuBarExtension.cs
@@ -1,8 +1,9 @@
-﻿using CairoDesktop.Common;
-using System.Windows.Controls;
-using CairoDesktop.Application.Interfaces;
+﻿using CairoDesktop.Application.Interfaces;
+using CairoDesktop.Common;
 using CairoDesktop.Infrastructure.ObjectModel;
 using ManagedShell.WindowsTray;
+using System.Collections.Generic;
+using System.Windows.Controls;
 
 namespace CairoDesktop.MenuBarExtensions
 {
@@ -10,7 +11,7 @@ namespace CairoDesktop.MenuBarExtensions
     {
         private readonly NotificationArea _notificationArea;
         private readonly Settings _settings;
-        private SystemTray _systemTray;
+        private List<SystemTray> _systemTrays = new List<SystemTray>();
 
         internal SystemTrayMenuBarExtension(NotificationArea notificationArea, Settings settings)
         {
@@ -25,8 +26,32 @@ namespace CairoDesktop.MenuBarExtensions
                 return null;
             }
 
-            _systemTray = new SystemTray(host, _notificationArea, _settings);
-            return _systemTray;
+            SystemTray tray = new SystemTray(host, _notificationArea, _settings);
+            _systemTrays.Add(tray);
+            return tray;
+        }
+
+        public override void StopControl(IMenuBar host)
+        {
+            List<SystemTray> toRemove = new List<SystemTray>();
+
+            foreach (SystemTray tray in _systemTrays)
+            {
+                if (tray.Host != host)
+                {
+                    continue;
+                }
+
+                tray.Host = null;
+                toRemove.Add(tray);
+            }
+
+            foreach (SystemTray tray in toRemove)
+            {
+                _systemTrays.Remove(tray);
+            }
+
+            toRemove.Clear();
         }
     }
 }

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTrayMenuBarExtension.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/SystemTrayMenuBarExtension.cs
@@ -11,7 +11,7 @@ namespace CairoDesktop.MenuBarExtensions
     {
         private readonly NotificationArea _notificationArea;
         private readonly Settings _settings;
-        private List<SystemTray> _systemTrays = new List<SystemTray>();
+        private readonly List<SystemTray> _systemTrays = new List<SystemTray>();
 
         internal SystemTrayMenuBarExtension(NotificationArea notificationArea, Settings settings)
         {
@@ -31,27 +31,13 @@ namespace CairoDesktop.MenuBarExtensions
             return tray;
         }
 
-        public override void StopControl(IMenuBar host)
+        public override void StopControl(IMenuBar host, UserControl control)
         {
-            List<SystemTray> toRemove = new List<SystemTray>();
-
-            foreach (SystemTray tray in _systemTrays)
+            if (control is SystemTray tray && _systemTrays.Contains(tray))
             {
-                if (tray.Host != host)
-                {
-                    continue;
-                }
-
                 tray.Host = null;
-                toRemove.Add(tray);
-            }
-
-            foreach (SystemTray tray in toRemove)
-            {
                 _systemTrays.Remove(tray);
             }
-
-            toRemove.Clear();
         }
     }
 }

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/Volume.xaml
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/Volume.xaml
@@ -1,7 +1,9 @@
 ﻿<UserControl x:Class="CairoDesktop.MenuBarExtensions.Volume"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:l10n="clr-namespace:CairoDesktop.Common.Localization;assembly=CairoDesktop.Common">
+             xmlns:l10n="clr-namespace:CairoDesktop.Common.Localization;assembly=CairoDesktop.Common"
+             Loaded="UserControl_Loaded"
+             Unloaded="UserControl_Unloaded">
     <Menu Style="{StaticResource CairoMenuBarMainContainerStyle}">
         <MenuItem x:Name="miOpenVolume"
                   Style="{StaticResource CairoMenuItemButtonMenuStyle}"

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/Volume.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/Volume.xaml.cs
@@ -1,29 +1,20 @@
-﻿using System;
+﻿using ManagedShell.Common.Helpers;
+using System;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Threading;
-using ManagedShell.Common.Helpers;
 
 namespace CairoDesktop.MenuBarExtensions
 {
     public partial class Volume : UserControl
     {
+        private bool _isLoaded;
+        private DispatcherTimer _volumeIconTimer;
+
         public Volume()
         {
             InitializeComponent();
-
-            InitializeVolumeIcon();
-        }
-
-        private void InitializeVolumeIcon()
-        {
-            VolumeIcon_Tick();
-
-            DispatcherTimer volumeIconTimer = new DispatcherTimer(new TimeSpan(0, 0, 0, 2), DispatcherPriority.Background, delegate
-            {
-                VolumeIcon_Tick();
-            }, Dispatcher);
         }
 
         private void VolumeIcon_Tick()
@@ -59,6 +50,36 @@ namespace CairoDesktop.MenuBarExtensions
         private void miOpenVolumeMixer_Click(object sender, RoutedEventArgs e)
         {
             ShellHelper.StartProcess("sndvol.exe", "-T " + (int)(((ushort)(System.Windows.Forms.Cursor.Position.X / DpiHelper.DpiScaleAdjustment)) | (uint)((int)ActualHeight << 16)));
+        }
+
+        private void UserControl_Loaded(object sender, RoutedEventArgs e)
+        {
+            if (_isLoaded)
+            {
+                return;
+            }
+
+            VolumeIcon_Tick();
+
+            _volumeIconTimer = new DispatcherTimer(new TimeSpan(0, 0, 0, 2), DispatcherPriority.Background, delegate
+            {
+                VolumeIcon_Tick();
+            }, Dispatcher);
+
+            _isLoaded = true;
+        }
+
+        private void UserControl_Unloaded(object sender, RoutedEventArgs e)
+        {
+            if (!_isLoaded)
+            {
+                return;
+            }
+
+            _volumeIconTimer?.Stop();
+            _volumeIconTimer = null;
+
+            _isLoaded = false;
         }
     }
 }


### PR DESCRIPTION
- Fixed IShellLink leak
- Introduced method to stop menu bar extension controls, so that they don't leak when a menu bar is closed
- Fixed other misc menu extra leaks
- Fixed menu commands event handler leak
- Hotkeys improved:
  - Hotkeys are no longer managed within individual instances of controls, which was bad, and fixes misc issues including leaks
  - Hotkeys that open menus now open the one on the same monitor as the mouse, if multiple menu bars are present
  - Toggling the Cairo and programs menu are now implemented as commands, which the hotkeys invoke
- Toggling menu bar items no longer requires Cairo restart
- Moved search initialization outside of the search control
- Hide search until initialized to prevent confusion