### PR TITLE
Migrate menu extra hotkeys to use commands

### DIFF
--- a/Cairo Desktop/Cairo Desktop/Program.cs
+++ b/Cairo Desktop/Cairo Desktop/Program.cs
@@ -20,6 +20,8 @@ using CairoDesktop.MenuBar.Services;
 using CairoDesktop.Taskbar.Services;
 using CairoDesktop.AppGrabber.Commands;
 using CairoDesktop.MenuBar.Commands;
+using CairoDesktop.MenuBarExtensions.Commands;
+using CairoDesktop.MenuBarExtensions.Services;
 
 namespace CairoDesktop
 {
@@ -64,6 +66,7 @@ namespace CairoDesktop
                     services.AddSingleton<ISettingsUIService, SettingsUIService>();
 
                     services.AddHostedService<MenuBarHotKeyService>();
+                    services.AddHostedService<MenuExtraHotKeyService>();
                     services.AddHostedService<ShellHotKeyService>();
 
                     services.AddSingleton<IThemeService, CairoApplicationThemeService>();
@@ -123,6 +126,8 @@ namespace CairoDesktop
                     services.AddSingleton<ICairoCommand, AddToQuickLaunchCommand>();
                     services.AddSingleton<ICairoCommand, ToggleCairoMenuCommand>();
                     services.AddSingleton<ICairoCommand, ToggleProgramsMenuCommand>();
+                    services.AddSingleton<ICairoCommand, ToggleCalendarCommand>();
+                    services.AddSingleton<ICairoCommand, ToggleSearchCommand>();
                 })
                 .ConfigureLogging((context, logging) =>
                 {

--- a/Cairo Desktop/CairoDesktop.Common/Localization/DisplayString.cs
+++ b/Cairo Desktop/CairoDesktop.Common/Localization/DisplayString.cs
@@ -734,5 +734,9 @@ namespace CairoDesktop.Common.Localization
         public static string sCommand_ToggleCairoMenu => getString();
 
         public static string sCommand_ToggleProgramsMenu => getString();
+
+        public static string sCommand_ToggleCalendar => getString();
+
+        public static string sCommand_ToggleSearch => getString();
     }
 }

--- a/Cairo Desktop/CairoDesktop.Common/Localization/Language.cs
+++ b/Cairo Desktop/CairoDesktop.Common/Localization/Language.cs
@@ -310,6 +310,8 @@ namespace CairoDesktop.Common.Localization
             { "sCommand_AddToQuickLaunch", "Add to quick launch" },
             { "sCommand_ToggleCairoMenu", "Toggle Cairo Menu" },
             { "sCommand_ToggleProgramsMenu", "Toggle Programs Menu" },
+            { "sCommand_ToggleCalendar", "Toggle Calendar" },
+            { "sCommand_ToggleSearch", "Toggle Search" },
         };
 
         public static Dictionary<string, string> pt_BR = new Dictionary<string, string>

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/ClockMenuBarExtension.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/ClockMenuBarExtension.cs
@@ -4,7 +4,6 @@ using CairoDesktop.Infrastructure.ObjectModel;
 using System;
 using System.Collections.Generic;
 using System.Windows.Controls;
-using System.Windows.Input;
 using CairoDesktop.Common.Helpers;
 
 namespace CairoDesktop.MenuBarExtensions
@@ -19,12 +18,6 @@ namespace CairoDesktop.MenuBarExtensions
         {
             _commandService = commandService;
             _settings = settings;
-
-            try
-            {
-                new HotKey(Key.D, HotKeyModifier.Win | HotKeyModifier.Alt | HotKeyModifier.NoRepeat, OnShowClock);
-            }
-            catch { }
 
             // register time changed handler to receive time zone updates for the clock to update correctly
             Microsoft.Win32.SystemEvents.TimeChanged += new EventHandler(TimeChanged);
@@ -51,7 +44,7 @@ namespace CairoDesktop.MenuBarExtensions
             }
         }
 
-        private void OnShowClock(HotKey hotKey)
+        internal void OnShowClock()
         {
             foreach (Clock clock in _clocks)
             {

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/Commands/ToggleCalendarCommand.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/Commands/ToggleCalendarCommand.cs
@@ -1,0 +1,82 @@
+﻿using CairoDesktop.Application.Interfaces;
+using CairoDesktop.Application.Structs;
+using CairoDesktop.Common;
+using CairoDesktop.Common.Localization;
+using System.Collections.Generic;
+
+namespace CairoDesktop.MenuBarExtensions.Commands
+{
+    public class ToggleCalendarCommand : ICairoCommand
+    {
+        public ICairoCommandInfo Info => _info;
+
+        private readonly Settings _settings;
+        private readonly MenuBarExtensionsShellExtension _menuExtrasExtension;
+        private readonly ToggleCalendarCommandInfo _info = new ToggleCalendarCommandInfo();
+
+        public ToggleCalendarCommand(IEnumerable<IShellExtension> shellExtensions, Settings settings)
+        {
+            foreach (var shellExtension in shellExtensions)
+            {
+                if (shellExtension is MenuBarExtensionsShellExtension menuExtrasExtension)
+                {
+                    _menuExtrasExtension = menuExtrasExtension;
+                }
+            }
+
+            _settings = settings;
+            _settings.PropertyChanged += Settings_PropertyChanged;
+            SetAvailable();
+        }
+
+        private void SetAvailable()
+        {
+            _info.IsAvailable = _settings.EnableMenuExtraClock;
+        }
+
+        private void Settings_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (e?.PropertyName == nameof(_settings.EnableMenuExtraClock))
+            {
+                SetAvailable();
+            }
+        }
+
+        public bool Execute(params (string name, object value)[] parameters)
+        {
+            if (_menuExtrasExtension == null || !_settings.EnableMenuExtraClock)
+            {
+                return false;
+            }
+
+            foreach (IMenuBarExtension menuExtra in _menuExtrasExtension.MenuExtras)
+            {
+                if (menuExtra is ClockMenuBarExtension clockMenuExtra)
+                {
+                    clockMenuExtra.OnShowClock();
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public void Dispose()
+        {
+            _settings.PropertyChanged -= Settings_PropertyChanged;
+        }
+    }
+
+    public class ToggleCalendarCommandInfo : ICairoCommandInfo
+    {
+        public string Identifier => "ToggleCalendar";
+
+        public string Description => "Toggles the calendar.";
+
+        public string Label => DisplayString.sCommand_ToggleCalendar;
+
+        public bool IsAvailable { get; internal set; }
+
+        public IReadOnlyCollection<CairoCommandParameter> Parameters => null;
+    }
+}

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/Commands/ToggleSearchCommand.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/Commands/ToggleSearchCommand.cs
@@ -1,0 +1,82 @@
+﻿using CairoDesktop.Application.Interfaces;
+using CairoDesktop.Application.Structs;
+using CairoDesktop.Common;
+using CairoDesktop.Common.Localization;
+using System.Collections.Generic;
+
+namespace CairoDesktop.MenuBarExtensions.Commands
+{
+    public class ToggleSearchCommand : ICairoCommand
+    {
+        public ICairoCommandInfo Info => _info;
+
+        private readonly Settings _settings;
+        private readonly MenuBarExtensionsShellExtension _menuExtrasExtension;
+        private readonly ToggleSearchCommandInfo _info = new ToggleSearchCommandInfo();
+
+        public ToggleSearchCommand(IEnumerable<IShellExtension> shellExtensions, Settings settings)
+        {
+            foreach (var shellExtension in shellExtensions)
+            {
+                if (shellExtension is MenuBarExtensionsShellExtension menuExtrasExtension)
+                {
+                    _menuExtrasExtension = menuExtrasExtension;
+                }
+            }
+
+            _settings = settings;
+            _settings.PropertyChanged += Settings_PropertyChanged;
+            SetAvailable();
+        }
+
+        private void SetAvailable()
+        {
+            _info.IsAvailable = _settings.EnableMenuExtraSearch;
+        }
+
+        private void Settings_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (e?.PropertyName == nameof(_settings.EnableMenuExtraSearch))
+            {
+                SetAvailable();
+            }
+        }
+
+        public bool Execute(params (string name, object value)[] parameters)
+        {
+            if (_menuExtrasExtension == null || !_settings.EnableMenuExtraSearch)
+            {
+                return false;
+            }
+
+            foreach (IMenuBarExtension menuExtra in _menuExtrasExtension.MenuExtras)
+            {
+                if (menuExtra is SearchMenuBarExtension searchMenuExtra)
+                {
+                    searchMenuExtra.OnShowSearch();
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public void Dispose()
+        {
+            _settings.PropertyChanged -= Settings_PropertyChanged;
+        }
+    }
+
+    public class ToggleSearchCommandInfo : ICairoCommandInfo
+    {
+        public string Identifier => "ToggleSearch";
+
+        public string Description => "Toggles the search panel.";
+
+        public string Label => DisplayString.sCommand_ToggleSearch;
+
+        public bool IsAvailable { get; internal set; }
+
+        public IReadOnlyCollection<CairoCommandParameter> Parameters => null;
+    }
+}

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/SearchMenuBarExtension.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/SearchMenuBarExtension.cs
@@ -2,14 +2,12 @@
 using CairoDesktop.Common;
 using CairoDesktop.Infrastructure.ObjectModel;
 using ManagedShell.Common.Helpers;
-using ManagedShell.Common.Logging;
 using ManagedShell.Interop;
 using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Windows.Controls;
 using System.Windows.Data;
-using System.Windows.Input;
 using System.Windows.Threading;
 using CairoDesktop.Common.Helpers;
 
@@ -27,15 +25,6 @@ namespace CairoDesktop.MenuBarExtensions
         {
             _cairoApplication = cairoApplication;
             _settings = settings;
-
-            try
-            {
-                new HotKey(Key.S, HotKeyModifier.Win | HotKeyModifier.NoRepeat, OnShowSearchHotkey);
-            }
-            catch (Exception ex)
-            {
-                ShellLogger.Warning($"Search: Unable to bind hotkey: {ex.Message}");
-            }
 
             if (_settings.EnableMenuExtraSearch)
             {
@@ -134,7 +123,7 @@ namespace CairoDesktop.MenuBarExtensions
             thread.Start();
         }
 
-        private void OnShowSearchHotkey(HotKey hotKey)
+        internal void OnShowSearch()
         {
             foreach (Search search in _searchList)
             {

--- a/Cairo Desktop/CairoDesktop.MenuBarExtensions/Services/MenuExtraHotKeyService.cs
+++ b/Cairo Desktop/CairoDesktop.MenuBarExtensions/Services/MenuExtraHotKeyService.cs
@@ -1,0 +1,113 @@
+﻿using CairoDesktop.Application.Interfaces;
+using CairoDesktop.Common;
+using CairoDesktop.Infrastructure.DependencyInjection;
+using System.Threading.Tasks;
+using System.Windows.Input;
+
+namespace CairoDesktop.MenuBarExtensions.Services
+{
+    public sealed class MenuExtraHotKeyService : CairoBackgroundService
+    {
+        private HotKey _calendarHotKey;
+        private HotKey _searchHotKey;
+
+        private readonly ICairoApplication _cairoApplication;
+        private readonly ICommandService _commandService;
+        private readonly Settings _settings;
+
+        public MenuExtraHotKeyService(ICairoApplication cairoApplication, ICommandService commandService, Settings settings)
+        {
+            _cairoApplication = cairoApplication;
+            _settings = settings;
+            _settings.PropertyChanged += Settings_PropertyChanged;
+
+            ServiceStartTask = new Task(RegisterHotkeys);
+            _commandService = commandService;
+        }
+
+        private void Settings_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (e == null || string.IsNullOrWhiteSpace(e.PropertyName)) return;
+
+            switch (e.PropertyName)
+            {
+                case nameof(_settings.EnableMenuExtraClock):
+                    if (_settings.EnableMenuExtraClock)
+                    {
+                        RegisterCalendarHotKey();
+                    }
+                    else
+                    {
+                        UnregisterCalendarHotKey();
+                    }
+
+                    break;
+                case nameof(_settings.EnableMenuExtraSearch):
+                    if (_settings.EnableMenuExtraSearch)
+                    {
+                        RegisterSearchHotKey();
+                    }
+                    else
+                    {
+                        UnregisterSearchHotKey();
+                    }
+
+                    break;
+            }
+        }
+
+        private void RegisterHotkeys()
+        {
+            RegisterCalendarHotKey();
+            RegisterSearchHotKey();
+        }
+
+        private void RegisterCalendarHotKey()
+        {
+            if (!_settings.EnableMenuExtraClock)
+            {
+                return;
+            }
+
+            _cairoApplication.Dispatch(() =>
+            {
+                _calendarHotKey = new HotKey(Key.D, HotKeyModifier.Win | HotKeyModifier.Alt | HotKeyModifier.NoRepeat, OnToggleCalendar);
+            });
+        }
+
+        private void UnregisterCalendarHotKey()
+        {
+            _calendarHotKey?.Dispose();
+            _calendarHotKey = null;
+        }
+
+        private void RegisterSearchHotKey()
+        {
+            if (!_settings.EnableMenuExtraSearch)
+            {
+                return;
+            }
+
+            _cairoApplication.Dispatch(() =>
+            {
+                _searchHotKey = new HotKey(Key.S, HotKeyModifier.Win | HotKeyModifier.NoRepeat, OnToggleSearch);
+            });
+        }
+
+        private void UnregisterSearchHotKey()
+        {
+            _searchHotKey?.Dispose();
+            _searchHotKey = null;
+        }
+
+        private void OnToggleCalendar(HotKey obj)
+        {
+            _commandService.InvokeCommand("ToggleCalendar");
+        }
+
+        private void OnToggleSearch(HotKey obj)
+        {
+            _commandService.InvokeCommand("ToggleSearch");
+        }
+    }
+}


### PR DESCRIPTION
- Now all hotkeys simply point to commands, will enable future changes to allow custom hotkey-command mappings
- Fixes minor regression from my last PR where hotkeys registered even while the clock or search are disabled