### PR TITLE
Fixes some ALT+F4 issues I was seeing

### DIFF
--- a/Cairo Desktop/CairoDesktop.Common/CairoMessage.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.Common/CairoMessage.xaml.cs
@@ -175,8 +175,8 @@ namespace CairoDesktop.Common
         /// <param name="OkButtonText">The text for the OK button.</param>
         /// <param name="CancelButtonText">The text for the cancel button.</param>
         /// <param name="resultCallback">The delegate to execute upon user action.</param>
-        /// <returns>void</returns>
-        public static void ShowOkCancel(string message, string title, CairoMessageImage image, string OkButtonText, string CancelButtonText, DialogResultDelegate resultCallback)
+        /// <returns>The CairoMessage instance that was shown.</returns>
+        public static CairoMessage ShowOkCancel(string message, string title, CairoMessageImage image, string OkButtonText, string CancelButtonText, DialogResultDelegate resultCallback)
         {
             if (string.IsNullOrEmpty(CancelButtonText))
             {
@@ -196,8 +196,10 @@ namespace CairoDesktop.Common
             msgDialog.ResultCallback = resultCallback;
             msgDialog.OkButton.Content = OkButtonText;
             msgDialog.CancelButton.Content = CancelButtonText;
-            
+
             msgDialog.Show();
+
+            return msgDialog;
         }
 
         /// <summary>

--- a/Cairo Desktop/CairoDesktop.Common/SystemPower.cs
+++ b/Cairo Desktop/CairoDesktop.Common/SystemPower.cs
@@ -1,19 +1,34 @@
 ﻿using CairoDesktop.Common.Localization;
 using System;
+using System.Collections.Generic;
 using ManagedShell.Common.Helpers;
 
 namespace CairoDesktop.Common
 {
     public class SystemPower
     {
+        // Keyed by title so repeated triggers (e.g. Alt+F4 fired from both the desktop and the
+        // desktop overlay in quick succession) bring the existing confirmation to the front instead
+        // of stacking duplicate dialogs.
+        private static readonly Dictionary<string, CairoMessage> _openConfirmations = new Dictionary<string, CairoMessage>();
+
         private static void ShowActionConfirmation(string message, string title, CairoMessageImage image, string okButtonText, string cancelButtonText, Action systemAction)
         {
-            CairoMessage.ShowOkCancel(message, title, image, okButtonText, cancelButtonText,
+            if (_openConfirmations.TryGetValue(title, out CairoMessage existingDialog))
+            {
+                existingDialog.Activate();
+                return;
+            }
+
+            CairoMessage msgDialog = CairoMessage.ShowOkCancel(message, title, image, okButtonText, cancelButtonText,
                 result =>
                 {
                     if (result == true)
                         systemAction();
                 });
+
+            _openConfirmations[title] = msgDialog;
+            msgDialog.Closed += (sender, e) => _openConfirmations.Remove(title);
         }
 
         public static void ShowShutdownConfirmation()

--- a/Cairo Desktop/CairoDesktop.DynamicDesktop/Desktop.xaml
+++ b/Cairo Desktop/CairoDesktop.DynamicDesktop/Desktop.xaml
@@ -17,7 +17,6 @@
         Closed="CairoDesktopWindow_Closed"
         SourceInitialized="Window_SourceInitialized"
         LocationChanged="CairoDesktopWindow_LocationChanged"
-        KeyDown="Window_KeyDown"
         MouseUp="CairoDesktopWindow_MouseUp"
         MouseRightButtonUp="CairoDesktopWindow_MouseRightButtonUp"
         DragOver="CairoDesktopWindow_DragOver"

--- a/Cairo Desktop/CairoDesktop.DynamicDesktop/Desktop.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.DynamicDesktop/Desktop.xaml.cs
@@ -127,7 +127,7 @@ namespace CairoDesktop.DynamicDesktop
                 handled = true;
             }
             else if (msg == (int)NativeMethods.WM.SYSKEYDOWN &&
-                    KeyInterop.KeyFromVirtualKey(wParam.ToInt32()) == Key.F4 &&
+                    wParam.ToInt32() == (int)NativeMethods.VK.F4 &&
                     Keyboard.Modifiers == ModifierKeys.Alt)
             {
                 // On the real Windows desktop, Alt+F4 shows the Shut Down Windows dialog rather than

--- a/Cairo Desktop/CairoDesktop.DynamicDesktop/Desktop.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.DynamicDesktop/Desktop.xaml.cs
@@ -36,7 +36,6 @@ namespace CairoDesktop.DynamicDesktop
     public partial class Desktop : Window, INotifyPropertyChanged
     {
         private WindowInteropHelper helper;
-        private bool altF4Pressed;
         private readonly ICairoApplication _cairoApplication;
         private readonly ICommandService _commandService;
         private readonly DesktopManager _desktopManager;
@@ -127,19 +126,31 @@ namespace CairoDesktop.DynamicDesktop
                 WorkAreaChanged?.Invoke(this, new EventArgs());
                 handled = true;
             }
+            else if (msg == (int)NativeMethods.WM.SYSKEYDOWN &&
+                    KeyInterop.KeyFromVirtualKey(wParam.ToInt32()) == Key.F4 &&
+                    Keyboard.Modifiers == ModifierKeys.Alt)
+            {
+                // On the real Windows desktop, Alt+F4 shows the Shut Down Windows dialog rather than
+                // closing anything. We handle this directly from the raw window message (instead of
+                // WPF's KeyDown routed event) because WM_SYSKEYDOWN is delivered to this window whenever
+                // it is the active desktop surface, even if it never received WPF keyboard focus - e.g.
+                // when the user hasn't clicked an icon first. This matches how explorer.exe's desktop
+                // responds to Alt+F4 without requiring a prior click.
+                //
+                // We check the live Alt key state via Keyboard.Modifiers rather than the WM_SYSKEYDOWN
+                // lParam's context-code bit: per MSDN, that bit is 0 (not 1) precisely when this message
+                // is being delivered to us because no window currently has keyboard focus - i.e. exactly
+                // the "bare desktop, nothing clicked" case this handler exists for.
+                SystemPower.ShowShutdownConfirmation();
+                handled = true;
+            }
 
             return IntPtr.Zero;
         }
 
         private void Window_Closing(object sender, CancelEventArgs e)
         {
-            if (altF4Pressed) // Show the Shutdown Confirmation Window
-            {
-                SystemPower.ShowShutdownConfirmation();
-                altF4Pressed = false;
-                e.Cancel = true;
-            }
-            else if (!AllowClose) // Eat it !!!
+            if (!AllowClose) // Eat it !!!
             {
                 e.Cancel = true;
             }
@@ -150,14 +161,6 @@ namespace CairoDesktop.DynamicDesktop
             // unsubscribe from things
             _settings.PropertyChanged -= Settings_PropertyChanged;
             _fullScreenHelper.FullScreenApps.CollectionChanged -= FullScreenApps_CollectionChanged;
-        }
-
-        private void Window_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
-        {
-            if (Keyboard.Modifiers == ModifierKeys.Alt && e.SystemKey == Key.F4)
-            {
-                altF4Pressed = true;
-            }
         }
 
         private void Window_SourceInitialized(object sender, EventArgs e)

--- a/Cairo Desktop/CairoDesktop.DynamicDesktop/DesktopOverlay.xaml
+++ b/Cairo Desktop/CairoDesktop.DynamicDesktop/DesktopOverlay.xaml
@@ -16,7 +16,6 @@
         Closing="Window_Closing"
         SourceInitialized="DesktopOverlayWindow_SourceInitialized"
         LocationChanged="DesktopOverlayWindow_LocationChanged"
-        KeyDown="DesktopOverlayWindow_KeyDown"
         MouseUp="DesktopOverlayWindow_MouseUp"
         MouseRightButtonUp="DesktopOverlayWindow_MouseRightButtonUp"
         DragOver="DesktopOverlayWindow_DragOver"

--- a/Cairo Desktop/CairoDesktop.DynamicDesktop/DesktopOverlay.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.DynamicDesktop/DesktopOverlay.xaml.cs
@@ -53,7 +53,7 @@ namespace CairoDesktop.DynamicDesktop
         private IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
         {
             if (msg == (int)NativeMethods.WM.SYSKEYDOWN &&
-                KeyInterop.KeyFromVirtualKey(wParam.ToInt32()) == Key.F4 &&
+                wParam.ToInt32() == (int)NativeMethods.VK.F4 &&
                 Keyboard.Modifiers == ModifierKeys.Alt)
             {
                 // Same rationale as Desktop.xaml.cs: the desktop overlay (shown when the user presses

--- a/Cairo Desktop/CairoDesktop.DynamicDesktop/DesktopOverlay.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.DynamicDesktop/DesktopOverlay.xaml.cs
@@ -3,6 +3,7 @@ using System;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Interop;
+using CairoDesktop.Common;
 using CairoDesktop.DynamicDesktop.Services;
 using ManagedShell.Common.Helpers;
 
@@ -49,6 +50,22 @@ namespace CairoDesktop.DynamicDesktop
             _desktopManager.IsOverlayOpen = false;
         }
 
+        private IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+        {
+            if (msg == (int)NativeMethods.WM.SYSKEYDOWN &&
+                KeyInterop.KeyFromVirtualKey(wParam.ToInt32()) == Key.F4 &&
+                Keyboard.Modifiers == ModifierKeys.Alt)
+            {
+                // Same rationale as Desktop.xaml.cs: the desktop overlay (shown when the user presses
+                // Win+D, since we dim over open windows rather than truly minimizing them) should also
+                // respond to Alt+F4 like the real Windows desktop does.
+                SystemPower.ShowShutdownConfirmation();
+                handled = true;
+            }
+
+            return IntPtr.Zero;
+        }
+
         private void DesktopOverlayWindow_SourceInitialized(object sender, EventArgs e)
         {
             WindowInteropHelper helper = new WindowInteropHelper(this);
@@ -56,17 +73,14 @@ namespace CairoDesktop.DynamicDesktop
 
             WindowHelper.HideWindowFromTasks(Handle);
 
+            HwndSource.FromHwnd(Handle).AddHook(new HwndSourceHook(WndProc));
+
             ResetPosition();
         }
 
         private void DesktopOverlayWindow_LocationChanged(object sender, EventArgs e)
         {
             ResetPosition();
-        }
-
-        private void DesktopOverlayWindow_KeyDown(object sender, KeyEventArgs e)
-        {
-            _desktopManager.DesktopWindow?.RaiseEvent(e);
         }
 
         private void DesktopOverlayWindow_MouseUp(object sender, MouseButtonEventArgs e)

--- a/Cairo Desktop/CairoDesktop.DynamicDesktop/Services/DesktopManager.cs
+++ b/Cairo Desktop/CairoDesktop.DynamicDesktop/Services/DesktopManager.cs
@@ -364,6 +364,10 @@ namespace CairoDesktop.DynamicDesktop.Services
                 DesktopOverlayWindow.Show();
                 DesktopOverlayWindow.BringToFront();
 
+                // give the overlay keyboard focus, matching how Win+D moves focus to the desktop on
+                // real Windows - without this, Alt+F4 has no window to be delivered to and is ignored
+                DesktopOverlayWindow.Activate();
+
                 // migrate the desktop icons control
                 DesktopWindow.grid.Children.Clear();
                 DesktopOverlayWindow.grid.Children.Add(DesktopIconsControl);


### PR DESCRIPTION
Fixes #295

Alt+F4 was supposed to show the "Shut Down Windows" dialog on the desktop, but only worked after clicking an icon first. Fixed by detecting Alt+F4 via a raw `WM_SYSKEYDOWN` hook instead of WPF's focus-dependent `KeyDown` event, applied to both the desktop and the Win+D overlay. Also made the confirmation dialog single-instance so triggering it twice doesn't stack duplicates.

**Tested manually:**
- Alt+F4 on bare desktop (no prior click) → dialog appears
- Alt+F4 on Win+D overlay → dialog appears
- Alt+F4 on desktop, then Win+D, then Alt+F4 again → existing dialog activated, not duplicated