### PR TITLE
Preserve original file name when dragging out of the Recycle Bin (#974)

### DIFF
--- a/Cairo Desktop/CairoDesktop.Common/CairoDesktop.Common.csproj
+++ b/Cairo Desktop/CairoDesktop.Common/CairoDesktop.Common.csproj
@@ -22,6 +22,10 @@
     <ProjectReference Include="..\CairoDesktop.Interop\CairoDesktop.Interop.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net480'">
+    <Reference Include="Microsoft.VisualBasic" />
+  </ItemGroup>
+
   <ItemGroup>
     <Resource Include="Resources\dialogIconCairo.png" />
     <Resource Include="Resources\dialogIconError.png" />

--- a/Cairo Desktop/CairoDesktop.Common/Helpers/FileDropHelper.cs
+++ b/Cairo Desktop/CairoDesktop.Common/Helpers/FileDropHelper.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using ManagedShell.Common.Logging;
+using ManagedShell.ShellFolders;
+using ManagedShell.ShellFolders.Enums;
+using Microsoft.VisualBasic.FileIO;
+
+namespace CairoDesktop.Common.Helpers
+{
+    /// <summary>
+    /// Recycle Bin items live on disk under a mangled physical name (e.g. $RXXXXXX.ext) that differs from
+    /// their original display name. FileOperationWorker names its destination after the dropped file's
+    /// on-disk name, so a plain move/copy would otherwise land under that mangled name instead of the
+    /// original one (unlike Explorer, which preserves it). This resolves the real name via the shell
+    /// namespace and performs the operation against those items directly, bypassing FileOperationWorker
+    /// only for the items that actually need renaming.
+    /// </summary>
+    public static class FileDropHelper
+    {
+        private const string RecycleBinPathSegment = "\\$RECYCLE.BIN\\";
+
+        public static void PerformOperation(FileOperationWorker fileWorker, string[] fileNames, string targetDirectory, bool isMove)
+        {
+            if (fileWorker == null || fileNames == null || fileNames.Length == 0)
+            {
+                return;
+            }
+
+            List<string> regularFiles = new List<string>();
+
+            foreach (string path in fileNames)
+            {
+                string originalName = TryGetRecycleBinDisplayName(path);
+
+                if (originalName != null &&
+                    !string.Equals(Path.GetFileName(path), originalName, StringComparison.OrdinalIgnoreCase))
+                {
+                    PerformNamedFileOperation(path, targetDirectory, originalName, isMove);
+                }
+                else
+                {
+                    regularFiles.Add(path);
+                }
+            }
+
+            if (regularFiles.Count > 0)
+            {
+                fileWorker.PerformOperation(isMove ? FileOperation.Move : FileOperation.Copy, regularFiles.ToArray(), targetDirectory);
+            }
+        }
+
+        private static string TryGetRecycleBinDisplayName(string physicalPath)
+        {
+            if (string.IsNullOrEmpty(physicalPath) ||
+                physicalPath.IndexOf(RecycleBinPathSegment, StringComparison.OrdinalIgnoreCase) < 0)
+            {
+                return null;
+            }
+
+            try
+            {
+                using (ShellFolder recycleBin = new ShellFolder("shell:RecycleBinFolder", IntPtr.Zero, false, false))
+                {
+                    foreach (ShellFile file in recycleBin.Files)
+                    {
+                        if (!string.Equals(file.Path, physicalPath, StringComparison.OrdinalIgnoreCase))
+                        {
+                            continue;
+                        }
+
+                        // ManagedShell's ShellFile.DisplayName for a Recycle Bin item is the item's
+                        // parsing name, which is the original *full path* (e.g.
+                        // "C:\Users\me\Downloads\report.txt"), not just the file name. Take the leaf so
+                        // the caller combines it with the drop target directory rather than restoring
+                        // the item to its original location. (If a future ShellFile revision returns a
+                        // bare name here, GetFileName is a harmless no-op.)
+                        string displayName = Path.GetFileName(file.DisplayName);
+
+                        if (string.IsNullOrEmpty(displayName))
+                        {
+                            return null;
+                        }
+
+                        string sourceExtension = Path.GetExtension(physicalPath);
+
+                        // A display name can omit the extension when "hide known extensions" is set, so
+                        // reattach the real extension (preserved by the Recycle Bin on the mangled
+                        // physical name) if needed.
+                        if (!string.IsNullOrEmpty(sourceExtension) &&
+                            !displayName.EndsWith(sourceExtension, StringComparison.OrdinalIgnoreCase))
+                        {
+                            displayName += sourceExtension;
+                        }
+
+                        return displayName;
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                ShellLogger.Warning($"FileDropHelper: Unable to resolve Recycle Bin display name for {physicalPath}: {e.Message}");
+            }
+
+            return null;
+        }
+
+        private static void PerformNamedFileOperation(string sourcePath, string targetDirectory, string destinationName, bool isMove)
+        {
+            Task.Run(() =>
+            {
+                try
+                {
+                    string destinationPath = Path.Combine(targetDirectory, destinationName);
+                    FileAttributes attributes = System.IO.File.GetAttributes(sourcePath);
+
+                    if ((attributes & FileAttributes.Directory) == FileAttributes.Directory)
+                    {
+                        if (isMove)
+                        {
+                            FileSystem.MoveDirectory(sourcePath, destinationPath, UIOption.AllDialogs);
+                        }
+                        else
+                        {
+                            FileSystem.CopyDirectory(sourcePath, destinationPath, UIOption.AllDialogs);
+                        }
+                    }
+                    else
+                    {
+                        if (isMove)
+                        {
+                            FileSystem.MoveFile(sourcePath, destinationPath, UIOption.AllDialogs);
+                        }
+                        else
+                        {
+                            FileSystem.CopyFile(sourcePath, destinationPath, UIOption.AllDialogs);
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    ShellLogger.Error($"FileDropHelper: Unable to {(isMove ? "move" : "copy")} {sourcePath} to {targetDirectory} as {destinationName}: {e.Message}");
+                }
+            });
+        }
+    }
+}

--- a/Cairo Desktop/CairoDesktop.Common/Icon.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.Common/Icon.xaml.cs
@@ -9,11 +9,11 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Effects;
 using System.Windows.Media.Imaging;
+using CairoDesktop.Common.Helpers;
 using ManagedShell.Common.Enums;
 using ManagedShell.Common.Helpers;
 using ManagedShell.Common.Logging;
 using ManagedShell.ShellFolders;
-using ManagedShell.ShellFolders.Enums;
 
 namespace CairoDesktop.Common
 {
@@ -292,9 +292,8 @@ namespace CairoDesktop.Common
 
                 if (fileNames != null && _fileWorker != null)
                 {
-                    _fileWorker.PerformOperation(isDropMove ? FileOperation.Move : FileOperation.Copy, 
-                        fileNames, 
-                        File.IsFolder ? File.Path : Path.GetDirectoryName(File.Path));
+                    FileDropHelper.PerformOperation(_fileWorker, fileNames,
+                        File.IsFolder ? File.Path : Path.GetDirectoryName(File.Path), isDropMove);
 
                     e.Handled = true;
                 }

--- a/Cairo Desktop/CairoDesktop.DynamicDesktop/Desktop.xaml.cs
+++ b/Cairo Desktop/CairoDesktop.DynamicDesktop/Desktop.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using CairoDesktop.Common;
+using CairoDesktop.Common.Helpers;
 using Microsoft.Win32;
 using System;
 using System.Collections.Specialized;
@@ -850,9 +851,7 @@ namespace CairoDesktop.DynamicDesktop
 
             if (fileNames != null && _desktopManager.DesktopLocation != null && _fileWorker != null)
             {
-                _fileWorker.PerformOperation(isDropMove ? FileOperation.Move : FileOperation.Copy, 
-                    fileNames, 
-                    _desktopManager.DesktopLocation.Path);
+                FileDropHelper.PerformOperation(_fileWorker, fileNames, _desktopManager.DesktopLocation.Path, isDropMove);
 
                 e.Handled = true;
             }


### PR DESCRIPTION
Fixes #974.

## Problem

Dragging a file out of the Windows Recycle Bin onto the Cairo desktop (or onto a desktop folder icon) creates it under its mangled on-disk name (e.g. `$RXXXXXXX.txt`) instead of its real name. Explorer preserves the original name here; Cairo did not.

## Root cause

`CairoDesktopWindow_Drop` (`Desktop.xaml.cs`) and the icon drop handler (`Icon.xaml.cs`) read only the `DataFormats.FileDrop` (CF_HDROP) paths from the drop. For a Recycle Bin item that path is the physical file under `$Recycle.Bin` (`C:\$Recycle.Bin\<SID>\$RXXXXXXX.ext`); the original name only lives in the paired `$IXXXXXXX` metadata file inside the Recycle Bin shell namespace. `FileOperationWorker.PerformOperation` then derives the destination name via `Path.GetFileName()` on the mangled path.

## Fix

New `FileDropHelper` (in `CairoDesktop.Common/Helpers/`), called by both drop handlers:

- For each dropped path under `$Recycle.Bin`, resolve the item via `shell:RecycleBinFolder` and recover its original name, then perform a per-item move/copy to the corrected name using the same `Microsoft.VisualBasic.FileIO` APIs `FileOperationWorker` uses internally.
- All other drops go through the normal batched `FileOperationWorker.PerformOperation`, unchanged.
- ManagedShell's resolved display name for a recycled item is the original **full path**, so only its leaf is used as the destination name — otherwise `Path.Combine` drops the target directory and the file is restored to its original location instead of landing on the desktop.
- Adds a `net480`-only `Microsoft.VisualBasic` reference to `CairoDesktop.Common`.

## Testing

Builds clean for `x64` across `net480`, `net6.0-windows`, `net10.0-windows`.

Manually verified running as the active shell:

- Deleted files from a folder **other than** the desktop folder, then dragged them out of the Recycle Bin window onto the Cairo desktop — they land on the desktop under their **real** names (`Q3 Forecast v2.txt`, `Team Roster.txt`), not `$R…` names, and are not restored to their original folder. Move and copy both verified.
- Normal (non-Recycle-Bin) drag-and-drop of a file onto the desktop is unaffected.
- Also exercised `FileDropHelper.PerformOperation` directly against real recycled items (move / copy / no-extension / non-recycle-bin control) — all land with the correct original name.

Note: because the corrected move/copy runs asynchronously (as the existing worker does), the item disappears from an open Recycle Bin window a moment after the drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)